### PR TITLE
Update cert-policy-and-rbac.yaml

### DIFF
--- a/main/templates/common/cert-policy-and-rbac.yaml
+++ b/main/templates/common/cert-policy-and-rbac.yaml
@@ -28,6 +28,7 @@ spec:
       - "signing"
       - "digital signature"
       - "server auth"
+      - "key encipherment"
 #  plugins:
 #    venafi:
 #      values:


### PR DESCRIPTION
adding - key encipherment to the usages. Without which the default ingress request certificate will be denied by this policy.