### PR TITLE
Update versions to match venctl 1.10, include csi-driver-spiffe in install. Min required venctl=1.10.0

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -131,6 +131,8 @@ generate-venafi-manifests:
 		--cert-manager-version ${cert-manager} \
 		--csi-driver \
 		--csi-driver-version ${cert-manager-csi-driver} \
+		--csi-driver-spiffe \
+		--csi-driver-spiffe-version ${cert-manager-csi-driver-spiffe} \
 		--accept-firefly-tos \
 		--firefly \
 		--firefly-version ${firefly} \
@@ -165,17 +167,20 @@ confirm:
 install: confirm
 	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${VEN_AGENT_SA_CLIENT_ID} \
 		FIREFLY_VENAFI_CLIENT_ID=${VEN_FIREFLY_SA_CLIENT_ID} \
+		CSI_DRIVER_SPIFFE_TRUST_DOMAIN=cluster.local \
 		venctl components kubernetes manifest tool sync --file artifacts/venafi-install/venafi-manifests.yaml 
 
 un-install:
 	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${VEN_AGENT_SA_CLIENT_ID} \
 		FIREFLY_VENAFI_CLIENT_ID=${VEN_FIREFLY_SA_CLIENT_ID} \
+		CSI_DRIVER_SPIFFE_TRUST_DOMAIN=cluster.local \
 		venctl components kubernetes manifest tool destroy --file artifacts/venafi-install/venafi-manifests.yaml 
 
 generate-static-manifests:
 	@echo "Generating static manifests if that's your preferred option"
 	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${VEN_AGENT_SA_CLIENT_ID} \
 		FIREFLY_VENAFI_CLIENT_ID=${VEN_FIREFLY_SA_CLIENT_ID} \
+		CSI_DRIVER_SPIFFE_TRUST_DOMAIN=cluster.local \
 		venctl components kubernetes manifest tool template --file artifacts/venafi-install/venafi-manifests.yaml > artifacts/venafi-install/kubernetes-manifests.yaml
 
 ################################### BEGIN Venafi Cloud Targets #####################################

--- a/main/versions.sh
+++ b/main/versions.sh
@@ -1,15 +1,16 @@
 # Versions based on output of 
 # venctl components kubernetes manifest print-versions
-export approver-policy-enterprise :="v0.16.0"
+export approver-policy-enterprise :="v0.17.0"
 export aws-privateca-issuer :="v1.2.7"
 export cert-manager :="v1.14.5"
-export cert-manager-approver-policy :="v0.14.0"
-export cert-manager-csi-driver :="v0.8.0"
+export cert-manager-approver-policy :="v0.14.1"
+export cert-manager-csi-driver :="v0.8.1"
+export cert-manager-csi-driver-spiffe :="v0.6.0"
 export firefly :="v1.3.4"
-export trust-manager :="v0.9.2"
-export venafi-connection :="v0.0.20"
-export venafi-enhanced-issuer :="v0.13.3"
-export venafi-kubernetes-agent :="0.1.47"
+export trust-manager :="v0.10.0"
+export venafi-connection :="v0.1.0"
+export venafi-enhanced-issuer :="v0.14.0"
+export venafi-kubernetes-agent :="0.1.48"
 
 # Used for installing istio-csr as it is not part of VMG at this time
 export VEN_CONTAINER_REGISTRY :=private-registry.venafi.cloud


### PR DESCRIPTION
Signed-off-by: Sitaram IYER <sitaramkm@gmail.com>