### PR TITLE
Update istio-csr to install & configure with venctl. Also updating component versions to latest venctl (1.16.0)

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -371,22 +371,32 @@ mesh-step1: mesh-setup
 
 _create_sourceCA:
 	@cp ${VEN_TRUST_ANCHOR_ROOT_CA_PEM} artifacts/venafi-install/venafi-trust-anchor-root-ca.pem
-	@kubectl create secret generic venafi-trust-anchor --namespace='venafi' --from-file=ca.crt=artifacts/venafi-install/venafi-trust-anchor-root-ca.pem --dry-run=client --save-config=true -o yaml | kubectl apply -f -
+	@kubectl create secret generic venafi-trust-anchor --namespace='venafi' --from-file=root-cert.pem=artifacts/venafi-install/venafi-trust-anchor-root-ca.pem --dry-run=client --save-config=true -o yaml | kubectl apply -f -
 
 mesh-step2: _create_sourceCA
 	@echo "Creating Firefly trust anchor"
+
+	@kubectl create configmap istio-csr-ca --namespace='venafi' \
+		--from-literal=issuer-name=firefly-mesh-wi-issuer \
+		--from-literal=issuer-kind=Issuer \
+		--from-literal=issuer-group=firefly.venafi.com \
+		--dry-run=client --save-config=true -o yaml | kubectl apply -f -
+
 	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/servicemesh/firefly-trust-anchor.yaml \
      > artifacts/venafi-install/firefly-trust-anchor.yaml
 	@kubectl apply -n istio-system -f artifacts/venafi-install/firefly-trust-anchor.yaml
 
 mesh-step3:
-	@echo 'Installing Venafi istio CSR agent.....'
-	@helm upgrade \
-	    --install -f artifacts/venafi-install/istio-csr-values.yaml cert-manager-istio-csr \
-  		--namespace venafi \
-		oci://${VEN_CONTAINER_REGISTRY}/charts/cert-manager-istio-csr \
-  		--version ${VEN_ISTIO_CSR_VERSION} \
-		--wait
+	@echo "Generating Venafi Helm manifests for installing istio-csr"
+	@venctl components kubernetes manifest generate \
+		--namespace venafi \
+		--istio-csr \
+		--istio-csr-version ${cert-manager-istio-csr} \
+		--istio-csr-values-files istio-csr-values.yaml \
+		--image-pull-secret-names venafi-image-pull-secret  > artifacts/venafi-install/venafi-manifests-istio.yaml
+
+	@ISTIO_TRUST_DOMAIN=cluster.local \
+		venctl components kubernetes manifest tool sync --file artifacts/venafi-install/venafi-manifests-istio.yaml 
 
 mesh-step4: _install-and-configure-istio
 
@@ -454,7 +464,8 @@ clean-mesh-setup:
 	@kubectl delete -f artifacts/venafi-install/venafi-cloud-publicca-cluster-issuer.yaml || true
 	@kubectl delete -f artifacts/venafi-install/peerauthentication.yaml || true
 	@istioctl uninstall -y -f artifacts/venafi-install/istio-config.yaml || true
-	@helm uninstall -n venafi cert-manager-istio-csr || true
+	@ISTIO_TRUST_DOMAIN=cluster.local \
+		venctl components kubernetes manifest tool sync --file artifacts/venafi-install/venafi-manifests-istio.yaml
 	@kubectl -n istio-system delete -f templates/servicemesh/firefly-mesh-wi-issuer.yaml || true
 	#more to delete here.
 	@kubectl -n istio-system delete -f artifacts/venafi-install/firefly-trust-anchor.yaml || true

--- a/main/templates/helm/istio-csr-values.yaml
+++ b/main/templates/helm/istio-csr-values.yaml
@@ -1,50 +1,3 @@
-# nameOverride replaces the name of the chart in the Chart.yaml file, when this
-# is used to construct Kubernetes object names.
-# +docs:property
-# nameOverride: approver-policy
-
-# Number of replicas of istio-csr to run.
-replicaCount: 1
-
-image:
-  # Target image registry. This value is prepended to the target image repository, if set.
-  # For example:
-  #   registry: quay.io
-  #   repository: jetstack/cert-manager-istio-csr
-  # +docs:property
-  # registry: quay.io
-
-  # Target image repository.
-  repository: ${VEN_CONTAINER_REGISTRY}/istio-csr/cert-manager-istio-csr
-
-  # Override the image tag to deploy by setting this variable.
-  # If no value is set, the chart's appVersion is used.
-  # +docs:property
-  tag: ${VEN_ISTIO_CSR_VERSION}
-
-  # Target image digest. Override any tag, if set.
-  # For example:
-  #   digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
-  # +docs:property
-  # digest: sha256:...
-
-  # Kubernetes imagePullPolicy on Deployment.
-  pullPolicy: IfNotPresent
-
-# Optional secrets used for pulling the istio-csr container image.
-imagePullSecrets:
-- name: ${VEN_DOCKER_REGISTRY_SECRET}
-
-service:
-  # Service type to expose istio-csr gRPC service.
-  type: ClusterIP
-  # Service port to expose istio-csr gRPC service.
-  port: 443
-  # Service nodePort to expose istio-csr gRPC service.
-  # +docs:type=number
-  # +docs:property
-  # nodePort:
-
 app:
   # Verbosity of istio-csr logging.
   logLevel: 1 # 1-5
@@ -79,13 +32,31 @@ app:
   # The "issuer-name", "issuer-kind" and "issuer-group" keys must be present in
   # the ConfigMap for it to be used.
   runtimeIssuanceConfigMap: ""
-
+  runtimeConfiguration:
+    # Create the runtime-configuration ConfigMap.
+    create: false
+    # Name of a ConfigMap in the installation namespace to watch, providing
+    # runtime configuration of an issuer to use.
+    #
+    # If create is set to true, then this name is used to create the ConfigMap,
+    # otherwise the ConfigMap must exist, and the "issuer-name", "issuer-kind"
+    # and "issuer-group" keys must be present in it.
+    name: "istio-csr-ca"
+    issuer:
+      # Issuer name set on created CertificateRequests for both istio-csr's
+      # serving certificate and incoming gRPC CSRs.
+      name: firefly-mesh-wi-issuer
+      # Issuer kind set on created CertificateRequests for both istio-csr's
+      # serving certificate and incoming gRPC CSRs.
+      kind: Issuer
+      # Issuer group name set on created CertificateRequests for both
+      # istio-csr's serving certificate and incoming gRPC CSRs.
+      group: venafi.firefly.com
   readinessProbe:
     # Container port to expose istio-csr HTTP readiness probe on default network interface.
     port: 6060
     # Path to expose istio-csr HTTP readiness probe on default network interface.
     path: "/readyz"
-
   certmanager:
     # Namespace to create CertificateRequests for both istio-csr's serving
     # certificate and incoming gRPC CSRs.
@@ -106,23 +77,31 @@ app:
     - name: firefly.venafi.com/policy-name
       value: firefly-istio-service-mesh-policy
     issuer:
+      # Enable the default issuer, this is the issuer used when no runtime
+      # configuration is provided.
+      #
+      # When enabled, the istio-csr Pod will not be "Ready" until the issuer
+      # has been used to issue the istio-csr GRPC certificate.
+      #
+      # For istio-csr to function, either this or runtime configuration must be
+      # enabled.
+      enabled: false
       # Issuer name set on created CertificateRequests for both istio-csr's
       # serving certificate and incoming gRPC CSRs.
-      name: "firefly-mesh-wi-issuer"
+      name: firefly-mesh-wi-issuer
       # Issuer kind set on created CertificateRequests for both istio-csr's
       # serving certificate and incoming gRPC CSRs.
       kind: Issuer
       # Issuer group name set on created CertificateRequests for both
       # istio-csr's serving certificate and incoming gRPC CSRs.
       group: firefly.venafi.com
-
   tls:
     # The Istio cluster's trust domain.
     trustDomain: "cluster.local"
     # An optional file location to a PEM encoded root CA that the root CA
     # ConfigMap in all namespaces will be populated with. If empty, the CA
     # returned from cert-manager for the serving certificate will be used.
-    rootCAFile: /var/run/secrets/firefly/ca.crt
+    rootCAFile: /var/run/secrets/firefly/root-cert.pem
     # The DNS names to request for the server's serving certificate which is
     # presented to istio-agents. istio-agents must route to istio-csr using one
     # of these DNS names.
@@ -153,6 +132,10 @@ app:
     istiodAdditionalDNSNames: []
 
   server:
+    authenticators:
+      # Enable the client certificate authenticator. This will allow workloads to use preexisting certificates to
+      # authenticate with istio-csr when rotating their certificate.
+      enableClientCert: false
     # The istio cluster ID to verify incoming CSRs.
     clusterID: "Kubernetes"
     # Maximum validity duration that can be requested for a certificate.
@@ -170,7 +153,8 @@ app:
       certificateKeySize: 2048
       # The type of signature algorithm to use when generating private keys. Currently only RSA and ECDSA are supported. By default RSA is used.
       signatureAlgorithm: "RSA"
-
+    # A comma-separated list of service accounts that are allowed to use node authentication for CSRs, e.g. "istio-system/ztunnel".
+    caTrustedNodeAccounts: ""
   istio:
     # The istio revisions that are currently installed in the cluster.
     # Changing this field will modify the DNS names that will be requested for
@@ -204,7 +188,14 @@ app:
     # [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/),
     # to avoid overloading the server.
     #disableKubernetesClientRateLimiter: false
-
+# Optional extra labels for deployment.
+deploymentLabels: {}
+# Optional extra annotations for deployment.
+deploymentAnnotations: {}
+# Optional extra labels for pod.
+podLabels: {}
+# Optional extra annotations for pod.
+podAnnotations: {}
 # Optional extra volumes. Useful for mounting custom root CAs
 #
 # For example:
@@ -212,14 +203,14 @@ app:
 #  - name: root-ca
 #    secret:
 #      secretName: root-cert
-#volumes: []
 volumes:
 - name: trust-domain-root
   configMap:
-   name: venafi-firefly-trust-anchor
+#   name: venafi-firefly-trust-anchor
+   name: istio-ca-root-cert
    items:
-     - key: ca.crt
-       path: ca.crt
+     - key: root-cert.pem
+       path: root-cert.pem
 
 # Optional extra volume mounts. Useful for mounting custom root CAs
 #
@@ -227,7 +218,7 @@ volumes:
 #  volumeMounts:
 #  - name: root-ca
 #    mountPath: /etc/tls
-#volumeMounts: []
+
 volumeMounts:
 - name: trust-domain-root
   mountPath: /var/run/secrets/firefly
@@ -268,7 +259,17 @@ affinity: {}
 #     value: master
 #     effect: NoSchedule
 tolerations: []
-
+# List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).
+# For example:
+#   topologySpreadConstraints:
+#   - maxSkew: 2
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: cert-manager-istio-csr
+#         app.kubernetes.io/instance: istio-csr
+topologySpreadConstraints: []
 # Kubernetes node selector: node labels for pod assignment.
 # +docs:property=nodeSelector
 nodeSelector:
@@ -281,3 +282,14 @@ commonLabels: {}
 #    environment: development
 #    app: mesh-apps
 #    issuer: venafi-firefly
+# Create resources alongside installing istio-csr, via Helm values. Can accept an array of YAML-formatted
+# resources. Each array entry can include multiple YAML documents, separated by '---'.
+#
+# For example:
+# extraObjects:
+#   - |
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: '{{ template "cert-manager-istio-csr.fullname" . }}-extra-configmap'
+extraObjects: []

--- a/main/templates/servicemesh/firefly-trust-anchor.yaml
+++ b/main/templates/servicemesh/firefly-trust-anchor.yaml
@@ -1,7 +1,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: venafi-firefly-trust-anchor
+  name: istio-ca-root-cert
 spec:
   sources:
   # Include a bundle of publicly trusted certificates which can be
@@ -10,12 +10,12 @@ spec:
   #- useDefaultCAs: true  
   - secret:
       name: "venafi-trust-anchor"
-      key: "ca.crt"
+      key: "root-cert.pem"
   target:
     # Data synced to the ConfigMap `my-org.com` or your private CA root at the key `ca.crt` in
     # every namespace based on the sources above.
     configMap:
-      key: "ca.crt"
+      key: "root-cert.pem"
     namespaceSelector:
       matchLabels:
          issuer: "venafi-firefly"

--- a/main/versions.sh
+++ b/main/versions.sh
@@ -1,20 +1,15 @@
 # Versions based on output of 
 # venctl components kubernetes manifest print-versions
-export approver-policy-enterprise :="v0.18.1"
+export approver-policy-enterprise :="v0.20.0"
 export aws-privateca-issuer :="v1.4.0"
-export cert-manager :="v1.16.1"
-export cert-manager-approver-policy :="v0.16.0"
-export cert-manager-csi-driver :="v0.10.1"
-export cert-manager-csi-driver-spiffe :="v0.8.1"
-export cert-manager-istio-csr :="v0.12.0"
+export cert-manager :="v1.16.3"
+export cert-manager-approver-policy :="v0.18.0"
+export cert-manager-csi-driver :="v0.10.2"
+export cert-manager-csi-driver-spiffe :="v0.8.2"
+export cert-manager-istio-csr :="v0.14.0"
 export firefly :="v1.5.0"
 export openshift-routes :="v0.7.0"
-export trust-manager :="v0.12.0"
-export venafi-connection :="v0.2.0"
-export venafi-enhanced-issuer :="v0.14.0"
-export venafi-kubernetes-agent :="1.1.0"
-
-# Used for installing istio-csr as it is not part of VMG at this time
-export VEN_CONTAINER_REGISTRY :=private-registry.venafi.cloud
-export VEN_ISTIO_CSR_VERSION :="v0.10.0"
-export VEN_DOCKER_REGISTRY_SECRET :=venafi-image-pull-secret
+export trust-manager :="v0.15.0"
+export venafi-connection :="v0.3.1"
+export venafi-enhanced-issuer :="v0.15.0"
+export venafi-kubernetes-agent :="1.4.0"


### PR DESCRIPTION
Updates to use latest istio-csr, 
Installing with venctl now. 
Component versions updated to latest supported by venctl (1.16.0)