### PR TITLE
Install goes into cyberark ns now. Env variables start with CYBR. Updates to readme

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -15,8 +15,8 @@ SHELL := /bin/sh
 -include cloud-settings.sh
 
 check-env:
-ifndef VEN_CLOUD_API_KEY
-	@(echo "VEN_CLOUD_API_KEY not defined. "; exit 1)
+ifndef CYBR_CLOUD_API_KEY
+	@(echo "CYBR_CLOUD_API_KEY not defined. "; exit 1)
 endif 
 
 ########################################################################################################################
@@ -37,7 +37,7 @@ init-dc: _init setup-datacenter-config
 
 mkdirs:
 	@rm -rf artifacts
-	@mkdir -p artifacts/venafi-install
+	@mkdir -p artifacts/cyberark-install
 	@mkdir -p artifacts/config
 	@mkdir -p artifacts/samples
 
@@ -53,19 +53,19 @@ create-sa-for-discovery:
 	@echo "Service account for certificate discovery"
 	@venctl iam service-accounts agent create \
 		--name "demo-agent-${RESOURCE_SUFFIX}" \
-		--output-file "artifacts/venafi-install/venafi_agent_secret.json" \
+		--output-file "artifacts/cyberark-install/cybr_mis_agent_secret.json" \
 		--output "secret" \
-		--owning-team "${VEN_TEAM_NAME}" \
+		--owning-team "${CYBR_TEAM_NAME}" \
 		--validity 10 \
-		--api-key ${VEN_CLOUD_API_KEY}
+		--api-key ${CYBR_CLOUD_API_KEY}
 
 create-discovery-secret: _transform_agent_secret_to_yaml
 	@echo "Credentials for certificate discovery"
-	@kubectl -n venafi apply -f artifacts/venafi-install/venafi_agent_secret.yaml || true
+	@kubectl -n cyberark apply -f artifacts/cyberark-install/cybr_mis_agent_secret.yaml || true
 
 _transform_agent_secret_to_yaml:
-	@jq -r '.private_key' artifacts/venafi-install/venafi_agent_secret.json > artifacts/venafi-install/venafi_agent_secret.yaml
-	@jq -r '.client_id' artifacts/venafi-install/venafi_agent_secret.json > artifacts/venafi-install/venafi_agent_client_id.txt
+	@jq -r '.private_key' artifacts/cyberark-install/cybr_mis_agent_secret.json > artifacts/cyberark-install/cybr_mis_agent_secret.yaml
+	@jq -r '.client_id' artifacts/cyberark-install/cybr_mis_agent_secret.json > artifacts/cyberark-install/cybr_mis_agent_client_id.txt
 
 ####################### END  - Targets to create Venafi Kubernetes Agent Service Account and secret ####################### 
 
@@ -75,19 +75,19 @@ create-sa-for-registry:
 	@echo "Creating Service Account in Venafi Control Plane for registry secret"
 	@venctl iam service-account registry create \
 		--name "demo-secret-${RESOURCE_SUFFIX}" \
-		--output-file "artifacts/venafi-install/venafi_registry_secret.json" \
+		--output-file "artifacts/cyberark-install/cybr_mis_registry_secret.json" \
 		--output "secret" \
-		--owning-team "${VEN_TEAM_NAME}" \
+		--owning-team "${CYBR_TEAM_NAME}" \
 		--validity 10 \
 		--scopes enterprise-cert-manager,enterprise-approver-policy,enterprise-venafi-issuer \
-		--api-key ${VEN_CLOUD_API_KEY}
+		--api-key ${CYBR_CLOUD_API_KEY}
 
 create-registry-secret: _transform_registry_secret_to_yaml
 	@echo "Credentials for venafi registry"
-	@kubectl -n venafi apply -f artifacts/venafi-install/venafi_registry_secret.yaml || true
+	@kubectl -n cyberark apply -f artifacts/cyberark-install/cybr_mis_registry_secret.yaml || true
 
 _transform_registry_secret_to_yaml:
-	@jq -r '.image_pull_secret' artifacts/venafi-install/venafi_registry_secret.json > artifacts/venafi-install/venafi_registry_secret.yaml
+	@jq -r '.image_pull_secret' artifacts/cyberark-install/cybr_mis_registry_secret.json > artifacts/cyberark-install/cybr_mis_registry_secret.yaml
 
 ####################### END - Targets to create Venafi Registry Service Account and secret ####################### 
 
@@ -97,26 +97,26 @@ create-sa-for-firefly:
 	@echo "Creating Service account in Venafi Control Plane for Firefly"
 	@venctl iam service-accounts firefly create \
 	--name "demo-firefly-${RESOURCE_SUFFIX}" \
-	--output-file "artifacts/venafi-install/venafi_firefly_secret.json" \
+	--output-file "artifacts/cyberark-install/cybr_mis_firefly_secret.json" \
 	--output "secret" \
-	--owning-team "${VEN_TEAM_NAME}" \
+	--owning-team "${CYBR_TEAM_NAME}" \
 	--validity 10 \
-	--api-key ${VEN_CLOUD_API_KEY}
+	--api-key ${CYBR_CLOUD_API_KEY}
 
 create-firefly-secret: _transform_firefly_secret_to_yaml
 	@echo "Credentials for Firefly"
-	@kubectl -n venafi apply -f artifacts/venafi-install/venafi_firefly_secret.yaml || true
+	@kubectl -n cyberark apply -f artifacts/cyberark-install/cybr_mis_firefly_secret.yaml || true
 
 _transform_firefly_secret_to_yaml:
 	@echo "Credentials for Venafi Firefly"
-	@jq -r '.private_key' artifacts/venafi-install/venafi_firefly_secret.json > artifacts/venafi-install/venafi_firefly_secret.yaml
-	@jq -r '.client_id' artifacts/venafi-install/venafi_firefly_secret.json > artifacts/venafi-install/venafi_firefly_client_id.txt
+	@jq -r '.private_key' artifacts/cyberark-install/cybr_mis_firefly_secret.json > artifacts/cyberark-install/cybr_mis_firefly_secret.yaml
+	@jq -r '.client_id' artifacts/cyberark-install/cybr_mis_firefly_secret.json > artifacts/cyberark-install/cybr_mis_firefly_client_id.txt
 
 
 ####################### END - Targets to create Venafi Firefly Service Account and secret ####################### 
 
 create-namespaces:
-	@kubectl apply -f namespaces/venafi.yaml
+	@kubectl apply -f namespaces/cyberark.yaml
 	@kubectl apply -f namespaces/sandbox.yaml
 
 configure-namespace: create-registry-secret create-discovery-secret create-firefly-secret
@@ -124,7 +124,7 @@ configure-namespace: create-registry-secret create-discovery-secret create-firef
 generate-venafi-manifests:
 	@echo "Generating Venafi Helm manifests for installation"
 	@venctl components kubernetes manifest generate \
-		--namespace venafi \
+		--namespace cyberark \
 		--approver-policy-enterprise \
 		--approver-policy-enterprise-version ${approver-policy-enterprise} \
 		--cert-manager \
@@ -146,10 +146,10 @@ generate-venafi-manifests:
  		--venafi-kubernetes-agent \
 		--venafi-kubernetes-agent-version ${venafi-kubernetes-agent} \
 		--venafi-kubernetes-agent-values-files venafi-agent.yaml \
-		--image-pull-secret-names venafi-image-pull-secret  > artifacts/venafi-install/venafi-manifests.yaml
+		--image-pull-secret-names venafi-image-pull-secret  > artifacts/cyberark-install/venafi-manifests.yaml
 
-VEN_AGENT_SA_CLIENT_ID ?= $(shell cat artifacts/venafi-install/venafi_agent_client_id.txt)
-VEN_FIREFLY_SA_CLIENT_ID ?= $(shell cat artifacts/venafi-install/venafi_firefly_client_id.txt)
+CYBR_AGENT_SA_CLIENT_ID ?= $(shell cat artifacts/cyberark-install/cybr_mis_agent_client_id.txt)
+CYBR_FIREFLY_SA_CLIENT_ID ?= $(shell cat artifacts/cyberark-install/cybr_mis_firefly_client_id.txt)
 
 confirm:
 	@while [ -z "$$CONFIRM" ]; do \
@@ -159,51 +159,51 @@ confirm:
 	if [ ! $$CONFIRM == "Y" ]; then \
 		echo "######################################################################\n" \
 		echo "The Firefly Config in the UI needs to be associated with the service\n" \
-		echo "account name that maps to client id ${VEN_FIREFLY_SA_CLIENT_ID}\n" \
+		echo "account name that maps to client id ${CYBR_FIREFLY_SA_CLIENT_ID}\n" \
 		echo "######################################################################" ; exit 1 ; \
 	fi \
 	fi
 
 install: confirm
-	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${VEN_AGENT_SA_CLIENT_ID} \
-		FIREFLY_VENAFI_CLIENT_ID=${VEN_FIREFLY_SA_CLIENT_ID} \
+	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${CYBR_AGENT_SA_CLIENT_ID} \
+		FIREFLY_VENAFI_CLIENT_ID=${CYBR_FIREFLY_SA_CLIENT_ID} \
 		CSI_DRIVER_SPIFFE_TRUST_DOMAIN=cluster.local \
-		venctl components kubernetes manifest tool sync --file artifacts/venafi-install/venafi-manifests.yaml 
+		venctl components kubernetes manifest tool sync --file artifacts/cyberark-install/venafi-manifests.yaml 
 
 un-install:
-	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${VEN_AGENT_SA_CLIENT_ID} \
-		FIREFLY_VENAFI_CLIENT_ID=${VEN_FIREFLY_SA_CLIENT_ID} \
+	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${CYBR_AGENT_SA_CLIENT_ID} \
+		FIREFLY_VENAFI_CLIENT_ID=${CYBR_FIREFLY_SA_CLIENT_ID} \
 		CSI_DRIVER_SPIFFE_TRUST_DOMAIN=cluster.local \
-		venctl components kubernetes manifest tool destroy --file artifacts/venafi-install/venafi-manifests.yaml 
+		venctl components kubernetes manifest tool destroy --file artifacts/cyberark-install/venafi-manifests.yaml 
 
 generate-static-manifests:
 	@echo "Generating static manifests if that's your preferred option"
-	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${VEN_AGENT_SA_CLIENT_ID} \
-		FIREFLY_VENAFI_CLIENT_ID=${VEN_FIREFLY_SA_CLIENT_ID} \
+	@VENAFI_KUBERNETES_AGENT_CLIENT_ID=${CYBR_AGENT_SA_CLIENT_ID} \
+		FIREFLY_VENAFI_CLIENT_ID=${CYBR_FIREFLY_SA_CLIENT_ID} \
 		CSI_DRIVER_SPIFFE_TRUST_DOMAIN=cluster.local \
-		venctl components kubernetes manifest tool template --file artifacts/venafi-install/venafi-manifests.yaml > artifacts/venafi-install/kubernetes-manifests.yaml
+		venctl components kubernetes manifest tool template --file artifacts/cyberark-install/venafi-manifests.yaml > artifacts/cyberark-install/kubernetes-manifests.yaml
 
 ################################### BEGIN Venafi Cloud Targets #####################################
 setup-cloud-config: create-agent-config-for-cloud create-vei-config-for-cloud
 
 create-vei-config-for-cloud:
-	@cp templates/helm/cloud-vei-values.yaml artifacts/venafi-install/vei-values.yaml 
+	@cp templates/helm/cloud-vei-values.yaml artifacts/cyberark-install/vei-values.yaml 
 
 create-agent-config-for-cloud:
-	@cat templates/helm/venafi-agent.yaml | sed -e "s/REPLACE_WITH_CLUSTER_NAME/demo-cluster-${RESOURCE_SUFFIX}/g" > artifacts/venafi-install/venafi-agent.yaml
+	@cat templates/helm/venafi-agent.yaml | sed -e "s/REPLACE_WITH_CLUSTER_NAME/mis-demo-cluster-${RESOURCE_SUFFIX}/g" > artifacts/cyberark-install/venafi-agent.yaml
 
 _create-venafi-cloud-access-secret: 
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/cloud/venafi-cloud-secret.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/cloud/venafi-cloud-secret.yaml \
      > artifacts/config/venafi-cloud-secret.yaml
 	@kubectl apply -f artifacts/config/venafi-cloud-secret.yaml
 
 _create-venafi-cloud-connection-with-access-token:
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/cloud/venafi-cloud-connection.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/cloud/venafi-cloud-connection.yaml \
      > artifacts/config/venafi-cloud-connection.yaml
 	@kubectl apply -f artifacts/config/venafi-cloud-connection.yaml
 
 create-venafi-cloud-privateca-cluster-issuer: _create-rbac-for-connections _create-venafi-cloud-access-secret _create-venafi-cloud-connection-with-access-token
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/cloud/venafi-cloud-privateca-cluster-issuer.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/cloud/venafi-cloud-privateca-cluster-issuer.yaml \
      > artifacts/config/venafi-cloud-privateca-cluster-issuer.yaml
 	@kubectl apply -f artifacts/config/venafi-cloud-privateca-cluster-issuer.yaml
 
@@ -222,37 +222,37 @@ create-certificate-policy:
 ################################### BEGIN Venafi Data center Targets #####################################
 
 get-venafi-token:
-	@vcert getcred --username ${VEN_USER_NAME} \
-		           --password ${VEN_USER_PASS} \
-				   -u ${VEN_SERVER_URL} \
-				   --client-id ${VEN_API_CLIENT} \
+	@vcert getcred --username ${CYBR_USER_NAME} \
+		           --password ${CYBR_USER_PASS} \
+				   -u ${CYBR_SERVER_URL} \
+				   --client-id ${CYBR_API_CLIENT} \
 				   --scope "certificate:manage,revoke" \
 				   --format json | tee /tmp/token
 
 setup-datacenter-config: create-venafi-tpp-trust-anchor create-agent-config-for-dc create-vei-config-for-dc
 
 create-vei-config-for-dc:
-	@cp templates/helm/datacenter-vei-values.yaml artifacts/venafi-install/vei-values.yaml 
+	@cp templates/helm/datacenter-vei-values.yaml artifacts/cyberark-install/vei-values.yaml 
 
 create-agent-config-for-dc:
-	@cat templates/helm/venafi-agent.yaml | sed -e "s/REPLACE_WITH_CLUSTER_NAME/demo-cluster-${RESOURCE_SUFFIX}/g" > artifacts/venafi-install/venafi-agent.yaml
+	@cat templates/helm/venafi-agent.yaml | sed -e "s/REPLACE_WITH_CLUSTER_NAME/mis-demo-cluster-${RESOURCE_SUFFIX}/g" > artifacts/cyberark-install/venafi-agent.yaml
 
 create-venafi-tpp-trust-anchor:
-	@cp ${VEN_TPP_CA_BUNDLE_PEM_FILE} artifacts/config/venafi-server-ca.pem
-	@kubectl create configmap venafi-tpp-ca-bundle --namespace='venafi' --from-file=ca.crt=artifacts/config/venafi-server-ca.pem --dry-run=client --save-config=true -o yaml | kubectl apply -f -
+	@cp ${CYBR_TPP_CA_BUNDLE_PEM_FILE} artifacts/config/venafi-server-ca.pem
+	@kubectl create configmap venafi-tpp-ca-bundle --namespace='cyberark' --from-file=ca.crt=artifacts/config/venafi-server-ca.pem --dry-run=client --save-config=true -o yaml | kubectl apply -f -
 
 _create-venafi-tpp-access-secret: 
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/dc/venafi-tpp-secret.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/dc/venafi-tpp-secret.yaml \
      > artifacts/config/venafi-tpp-secret.yaml
 	@kubectl apply -f artifacts/config/venafi-tpp-secret.yaml
 
 _create-venafi-tpp-connection-with-access-token:
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/dc/venafi-tpp-connection.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/dc/venafi-tpp-connection.yaml \
      > artifacts/config/venafi-tpp-connection.yaml
 	@kubectl apply -f artifacts/config/venafi-tpp-connection.yaml
 
 create-venafi-tpp-privateca-cluster-issuer: _create-rbac-for-connections _create-venafi-tpp-access-secret _create-venafi-tpp-connection-with-access-token
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/dc/venafi-tpp-privateca-cluster-issuer.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/dc/venafi-tpp-privateca-cluster-issuer.yaml \
      > artifacts/config/venafi-tpp-privateca-cluster-issuer.yaml
 	@kubectl apply -f artifacts/config/venafi-tpp-privateca-cluster-issuer.yaml
 
@@ -260,27 +260,27 @@ create-venafi-tpp-privateca-cluster-issuer: _create-rbac-for-connections _create
 ################################### END Venafi Data center Targets #####################################
 
 ################################## SAMPLES ##################################
-#seed-data-tpp: VEN_CLUSTER_ISSUER=venafi-tpp-privateca-cluster-issuer
+#seed-data-tpp: CYBR_CLUSTER_ISSUER=venafi-tpp-privateca-cluster-issuer
 #seed-data-tpp: _seed-data
 
-#seed-data-cloud: VEN_CLUSTER_ISSUER=venafi-cloud-privateca-cluster-issuer
+#seed-data-cloud: CYBR_CLUSTER_ISSUER=venafi-cloud-privateca-cluster-issuer
 #seed-data-cloud: _seed-data
 
-seed-data: VEN_CLUSTER_ISSUER=venafi-privateca-cluster-issuer
+seed-data: CYBR_CLUSTER_ISSUER=venafi-privateca-cluster-issuer
 seed-data: _seed-data
 
 _seed-data:
-	@echo "Creating certificate resources with issuer as ${VEN_CLUSTER_ISSUER}"
+	@echo "Creating certificate resources with issuer as ${CYBR_CLUSTER_ISSUER}"
 #Self signed cert
 	@./samples/01.unmanaged-kid.sh
 #Cert with long duration mounted on a pod
-	@cat templates/certs/02-expiry-eddie-cert.yaml | sed -e "s/REPLACE_WITH_ISSUER_NAME/${VEN_CLUSTER_ISSUER}/g" > artifacts/samples/02-expiry-eddie-cert.yaml
+	@cat templates/certs/02-expiry-eddie-cert.yaml | sed -e "s/REPLACE_WITH_ISSUER_NAME/${CYBR_CLUSTER_ISSUER}/g" > artifacts/samples/02-expiry-eddie-cert.yaml
 	@kubectl apply -f artifacts/samples/02-expiry-eddie-cert.yaml
 	@./samples/02.expiry-eddie.sh
 #Cert with bad key size
 	@./samples/03.cipher-snake.sh
 #Orphan cert
-	@cat templates/certs/04-ghost-rider-cert.yaml | sed -e "s/REPLACE_WITH_ISSUER_NAME/${VEN_CLUSTER_ISSUER}/g" > artifacts/samples/04-ghost-rider-cert.yaml
+	@cat templates/certs/04-ghost-rider-cert.yaml | sed -e "s/REPLACE_WITH_ISSUER_NAME/${CYBR_CLUSTER_ISSUER}/g" > artifacts/samples/04-ghost-rider-cert.yaml
 	@kubectl apply -f artifacts/samples/04-ghost-rider-cert.yaml
 #phanton ca and cert
 	@kubectl apply -f samples/cert-policy-and-rbac-self-signed.yaml 
@@ -323,8 +323,8 @@ _remove-common-issuer-resources:
 	@kubectl delete -f templates/common/venafi-connection-rbac.yaml || true
 
 remove-secrets:
-	@kubectl -n venafi delete -f artifacts/venafi-install/venafi_agent_secret.yaml || true
-	@kubectl -n venafi delete -f artifacts/venafi-install/venafi_registry_secret.yaml || true
+	@kubectl -n cyberark delete -f artifacts/cyberark-install/cybr_mis_agent_secret.yaml || true
+	@kubectl -n cyberark delete -f artifacts/cyberark-install/cybr_mis_registry_secret.yaml || true
 
 remove-seed-data:
 
@@ -352,7 +352,7 @@ remove-seed-data:
 	@kubectl -n sandbox delete secret unmanaged-kid.svc.cluster.local || true
 
 clean: remove-seed-data remove-sample-firefly-certs remove-policy remove-issuer-resources un-install remove-secrets
-	@kubectl delete -f namespaces/venafi.yaml || true
+	@kubectl delete -f namespaces/cyberark.yaml || true
 	@kubectl delete -f namespaces/sandbox.yaml || true
 	@kubectl delete clusterrole venafi-issuer-cluster-role || true
 	@kubectl delete clusterrolebinding venafi-issuer-cluster-role-binding || true
@@ -365,49 +365,49 @@ mesh-setup:
 	@kubectl apply -f namespaces/mesh-apps.yaml
 
 mesh-step1: mesh-setup
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/helm/istio-csr-values.yaml \
-     > artifacts/venafi-install/istio-csr-values.yaml
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/helm/istio-csr-values.yaml \
+     > artifacts/cyberark-install/istio-csr-values.yaml
 	@kubectl apply -n istio-system -f templates/servicemesh/firefly-mesh-wi-issuer.yaml 
 
 _create_sourceCA:
-	@cp ${VEN_TRUST_ANCHOR_ROOT_CA_PEM} artifacts/venafi-install/venafi-trust-anchor-root-ca.pem
-	@kubectl create secret generic venafi-trust-anchor --namespace='venafi' --from-file=root-cert.pem=artifacts/venafi-install/venafi-trust-anchor-root-ca.pem --dry-run=client --save-config=true -o yaml | kubectl apply -f -
+	@cp ${CYBR_TRUST_ANCHOR_ROOT_CA_PEM} artifacts/cyberark-install/cyberark-trust-anchor-root-ca.pem
+	@kubectl create secret generic cyberark-trust-anchor --namespace='cyberark' --from-file=root-cert.pem=artifacts/cyberark-install/cyberark-trust-anchor-root-ca.pem --dry-run=client --save-config=true -o yaml | kubectl apply -f -
 
 mesh-step2: _create_sourceCA
 	@echo "Creating Firefly trust anchor"
 
-	@kubectl create configmap istio-csr-ca --namespace='venafi' \
+	@kubectl create configmap istio-csr-ca --namespace='cyberark' \
 		--from-literal=issuer-name=firefly-mesh-wi-issuer \
 		--from-literal=issuer-kind=Issuer \
 		--from-literal=issuer-group=firefly.venafi.com \
 		--dry-run=client --save-config=true -o yaml | kubectl apply -f -
 
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/servicemesh/firefly-trust-anchor.yaml \
-     > artifacts/venafi-install/firefly-trust-anchor.yaml
-	@kubectl apply -n istio-system -f artifacts/venafi-install/firefly-trust-anchor.yaml
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/servicemesh/firefly-trust-anchor.yaml \
+     > artifacts/cyberark-install/firefly-trust-anchor.yaml
+	@kubectl apply -n istio-system -f artifacts/cyberark-install/firefly-trust-anchor.yaml
 
 mesh-step3:
 	@echo "Generating Venafi Helm manifests for installing istio-csr"
 	@venctl components kubernetes manifest generate \
-		--namespace venafi \
+		--namespace cyberark \
 		--istio-csr \
 		--istio-csr-version ${cert-manager-istio-csr} \
 		--istio-csr-values-files istio-csr-values.yaml \
-		--image-pull-secret-names venafi-image-pull-secret  > artifacts/venafi-install/venafi-manifests-istio.yaml
+		--image-pull-secret-names venafi-image-pull-secret  > artifacts/cyberark-install/venafi-manifests-istio.yaml
 
 	@ISTIO_TRUST_DOMAIN=cluster.local \
-		venctl components kubernetes manifest tool sync --file artifacts/venafi-install/venafi-manifests-istio.yaml 
+		venctl components kubernetes manifest tool sync --file artifacts/cyberark-install/venafi-manifests-istio.yaml 
 
 mesh-step4: _install-and-configure-istio
 
 _install-and-configure-istio:
-	@cp templates/servicemesh/istio-config.yaml artifacts/venafi-install/istio-config.yaml
-	@istioctl install -y -f artifacts/venafi-install/istio-config.yaml
+	@cp templates/servicemesh/istio-config.yaml artifacts/cyberark-install/istio-config.yaml
+	@istioctl install -y -f artifacts/cyberark-install/istio-config.yaml
 
 mesh-step5: _create-peer-authentication
 _create-peer-authentication:
-	@cp templates/servicemesh/peerauthentication.yaml artifacts/venafi-install/peerauthentication.yaml
-	@kubectl apply -f artifacts/venafi-install/peerauthentication.yaml
+	@cp templates/servicemesh/peerauthentication.yaml artifacts/cyberark-install/peerauthentication.yaml
+	@kubectl apply -f artifacts/cyberark-install/peerauthentication.yaml
 
 mesh-step6:
 	@kubectl -n mesh-apps apply -f https://raw.githubusercontent.com/sitaramkm/microservices-demo/refs/heads/main/release/kubernetes-manifests.yaml
@@ -422,39 +422,38 @@ _install-istio-tools:
 mesh-step8-cloud: _create-tlspc-public-cert-issuer _create-tlspc-public-cert
 
 _create-tlspc-public-cert-issuer:
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml \
-     > artifacts/venafi-install/venafi-cloud-publicca-cluster-issuer.yaml
-	@kubectl apply -f artifacts/venafi-install/venafi-cloud-publicca-cluster-issuer.yaml
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml \
+     > artifacts/cyberark-install/venafi-cloud-publicca-cluster-issuer.yaml
+	@kubectl apply -f artifacts/cyberark-install/venafi-cloud-publicca-cluster-issuer.yaml
 _create-tlspc-public-cert:
 	@cat templates/cloud/venafi-cloud-managed-public-cert.yaml | sed -e "s/REPLACE_WITH_SUB_DOMAIN/${RESOURCE_SUFFIX}/g" \
-	> artifacts/venafi-install/venafi-cloud-managed-public-cert-tmp.yaml
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < artifacts/venafi-install/venafi-cloud-managed-public-cert-tmp.yaml \
-     > artifacts/venafi-install/venafi-cloud-managed-public-cert.yaml
-	@kubectl apply -f artifacts/venafi-install/venafi-cloud-managed-public-cert.yaml
+	> artifacts/cyberark-install/venafi-cloud-managed-public-cert-tmp.yaml
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < artifacts/cyberark-install/venafi-cloud-managed-public-cert-tmp.yaml \
+     > artifacts/cyberark-install/venafi-cloud-managed-public-cert.yaml
+	@kubectl apply -f artifacts/cyberark-install/venafi-cloud-managed-public-cert.yaml
 
 mesh-step8-tpp: _create-tpp-public-cert-issuer _create-tpp-public-cert
 _create-tpp-public-cert-issuer:
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < templates/dc/venafi-tpp-publicca-cluster-issuer.yaml \
-     > artifacts/venafi-install/venafi-tpp-publicca-cluster-issuer.yaml
-	@kubectl apply -f artifacts/venafi-install/venafi-tpp-publicca-cluster-issuer.yaml
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < templates/dc/venafi-tpp-publicca-cluster-issuer.yaml \
+     > artifacts/cyberark-install/venafi-tpp-publicca-cluster-issuer.yaml
+	@kubectl apply -f artifacts/cyberark-install/venafi-tpp-publicca-cluster-issuer.yaml
 _create-tpp-public-cert:
 	@cat templates/dc/venafi-tpp-managed-public-cert.yaml | sed -e "s/REPLACE_WITH_SUB_DOMAIN/${RESOURCE_SUFFIX}/g" \
-	> artifacts/venafi-install/venafi-tpp-managed-public-cert-tmp.yaml
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < artifacts/venafi-install/venafi-tpp-managed-public-cert-tmp.yaml \
-     > artifacts/venafi-install/venafi-tpp-managed-public-cert.yaml
-	@kubectl apply -f artifacts/venafi-install/venafi-tpp-managed-public-cert.yaml
+	> artifacts/cyberark-install/venafi-tpp-managed-public-cert-tmp.yaml
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < artifacts/cyberark-install/venafi-tpp-managed-public-cert-tmp.yaml \
+     > artifacts/cyberark-install/venafi-tpp-managed-public-cert.yaml
+	@kubectl apply -f artifacts/cyberark-install/venafi-tpp-managed-public-cert.yaml
 
 #mesh-step9: _create_entry_in_GCP_CloudDNS
 mesh-step9: _create_entry_in_AWS_Route53
 	
 _create_entry_in_GCP_CloudDNS:
-	@echo "Create DNS entry for ${RESOURCE_SUFFIX}.${VEN_DOMAIN_FOR_SAMPLE_APP} to map to Gateway host/ip"
-	@../scripts/gcp/map-dns-to-gateway.sh ${VEN_GCP_ZONE} ${RESOURCE_SUFFIX}.${VEN_DOMAIN_FOR_SAMPLE_APP}
+	@echo "Create DNS entry for ${RESOURCE_SUFFIX}.${CYBR_DOMAIN_FOR_SAMPLE_APP} to map to Gateway host/ip"
+	@../scripts/gcp/map-dns-to-gateway.sh ${CYBR_GCP_ZONE} ${RESOURCE_SUFFIX}.${CYBR_DOMAIN_FOR_SAMPLE_APP}
 
 _create_entry_in_AWS_Route53:
-	@echo "Create DNS entry for ${RESOURCE_SUFFIX}.${VEN_DOMAIN_FOR_SAMPLE_APP} to map to Gateway host/ip"
-	@../scripts/aws/map-dns-to-gateway.sh ${VEN_AWS_ZONE} ${RESOURCE_SUFFIX}.${VEN_DOMAIN_FOR_SAMPLE_APP}
-
+	@echo "Create DNS entry for ${RESOURCE_SUFFIX}.${CYBR_DOMAIN_FOR_SAMPLE_APP} to map to Gateway host/ip"
+	@../scripts/aws/map-dns-to-gateway.sh ${CYBR_AWS_ZONE} ${RESOURCE_SUFFIX}.${CYBR_DOMAIN_FOR_SAMPLE_APP}
 
 mesh-step10:  _create_gateway_resources
 
@@ -464,14 +463,13 @@ _install-sample-app:
 _create_gateway_resources:
 	@cat templates/servicemesh/sample-app-gateway.yaml | sed -e "s/REPLACE_WITH_SUB_DOMAIN/${RESOURCE_SUFFIX}/g" \
 	> artifacts/samples/sample-app-gateway-tmp.yaml
-	@envsubst "$$(printf '$${%s} ' $${!VEN_*})" < artifacts/samples/sample-app-gateway-tmp.yaml \
+	@envsubst "$$(printf '$${%s} ' $${!CYBR_*})" < artifacts/samples/sample-app-gateway-tmp.yaml \
      > artifacts/samples/sample-app-gateway.yaml
 	@kubectl -n mesh-apps apply -f artifacts/samples/sample-app-gateway.yaml
 	@echo "####################################################################################################"
 	@echo "######### Sample apps takes about 60 seconds before pods are Ready in mesh-apps namespace ##########"
-	@echo "######### Access application using https://${RESOURCE_SUFFIX}.${VEN_DOMAIN_FOR_SAMPLE_APP}/      ###"
+	@echo "######### Access application using https://${RESOURCE_SUFFIX}.${CYBR_DOMAIN_FOR_SAMPLE_APP}/     ###"
 	@echo "####################################################################################################"
-
 	
 clean-mesh-setup:
 	@kubectl -n mesh-apps delete -f artifacts/samples/sample-app-gateway.yaml || true
@@ -480,18 +478,18 @@ clean-mesh-setup:
 	@kubectl delete -f https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.24/samples/addons/kiali.yaml || true
 	@kubectl delete -f https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.24/samples/addons/prometheus.yaml || true
 	@kubectl delete -f https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.24/samples/addons/grafana.yaml || true
-	@kubectl delete -f artifacts/venafi-install/venafi-tpp-managed-public-cert.yaml || true
-	@kubectl delete -f artifacts/venafi-install/venafi-tpp-publicca-cluster-issuer.yaml || true
-	@kubectl delete -f artifacts/venafi-install/venafi-cloud-managed-public-cert.yaml || true
-	@kubectl delete -f artifacts/venafi-install/venafi-cloud-publicca-cluster-issuer.yaml || true
-	@kubectl delete -f artifacts/venafi-install/peerauthentication.yaml || true
-	@istioctl uninstall -y -f artifacts/venafi-install/istio-config.yaml || true
+	@kubectl delete -f artifacts/cyberark-install/venafi-tpp-managed-public-cert.yaml || true
+	@kubectl delete -f artifacts/cyberark-install/venafi-tpp-publicca-cluster-issuer.yaml || true
+	@kubectl delete -f artifacts/cyberark-install/venafi-cloud-managed-public-cert.yaml || true
+	@kubectl delete -f artifacts/cyberark-install/venafi-cloud-publicca-cluster-issuer.yaml || true
+	@kubectl delete -f artifacts/cyberark-install/peerauthentication.yaml || true
+	@istioctl uninstall -y -f artifacts/cyberark-install/istio-config.yaml || true
 	@ISTIO_TRUST_DOMAIN=cluster.local \
-		venctl components kubernetes manifest tool sync --file artifacts/venafi-install/venafi-manifests-istio.yaml
+		venctl components kubernetes manifest tool sync --file artifacts/cyberark-install/venafi-manifests-istio.yaml
 	@kubectl -n istio-system delete -f templates/servicemesh/firefly-mesh-wi-issuer.yaml || true
 	#more to delete here.
-	@kubectl -n istio-system delete -f artifacts/venafi-install/firefly-trust-anchor.yaml || true
-	@kubectl delete secret venafi-trust-anchor --namespace='venafi' || true
+	@kubectl -n istio-system delete -f artifacts/cyberark-install/firefly-trust-anchor.yaml || true
+	@kubectl delete secret cyberark-trust-anchor --namespace='cyberark' || true
 	@kubectl delete -f namespaces/mesh-apps.yaml || true
 	@kubectl delete -f namespaces/istio-system.yaml || true
 	@kubectl delete clusterrole istiod-istio-system || true
@@ -500,7 +498,7 @@ clean-mesh-setup:
 	@kubectl delete clusterrolebinding istio-reader-istio-system || true
 	@kubectl get crds | grep 'istio.io' |   xargs -n1 -I{} sh -c "kubectl delete crd {}" || true
 	
-print-svid: PODNAME=$$(kubectl get pods -n mesh-apps -o jsonpath='{.items..metadata.name}' --selector app=ratings ) 
+print-svid: PODNAME=$$(kubectl get pods -n mesh-apps -o jsonpath='{.items..metadata.name}' --selector app=frontend ) 
 print-svid:
 	@echo "Pod name is ${PODNAME}"
 	@istioctl -n mesh-apps proxy-config secret ${PODNAME} \
@@ -513,8 +511,8 @@ print-svid:
 #helper target to clean up unused Firefly intermediates
 delete-firefly-intermediateCertificates:
 	@echo "Delete Firefly intermediate certificate"
-	@curl --location --request DELETE 'https://api.venafi.cloud/v1/distributedissuers/intermediatecertificates/e931c810-f36e-11ee-a89e-b3d87834cdaf' \
-	--header 'tppl-api-key: ${VEN_CLOUD_API_KEY}' \
+	@curl --location --request DELETE 'https://api.venafi.cloud/v1/distributedissuers/intermediatecertificates/a3ca3090-e315-11ef-a87f-d19628edae70' \
+	--header 'tppl-api-key: ${CYBR_CLOUD_API_KEY}' \
 	--header 'Content-Type: application/json'
 
 #helper target to generate a public/private key pair for routing discoverd certs from VCP to TPP
@@ -537,3 +535,12 @@ _remove-gcloud-cluster:
 
 gcp-full-cleanup: _remove-gcloud-cluster
 	@$(MAKE) -C ../scripts remove-google-cas --warn-undefined-variables
+
+get-all-issuers:
+	@kubectl get ClusterIssuer,Issuer,VenafiClusterIssuer,VenafiIssuer,issuers.firefly.venafi.com --all-namespaces -o custom-columns='Issuer_NAME:.metadata.name,Resource:.apiVersion,STATUS:.status.conditions[].type' 
+
+get-all-policies:
+	@kubectl get crp
+
+get-all-secrets:
+	@kubectl get secrets -A -o json | jq '.items[] | select(.type=="kubernetes.io/tls") | .metadata.name'

--- a/main/README.md
+++ b/main/README.md
@@ -16,16 +16,16 @@ The demos use a `Makefile` for all operations. Always review the target you are 
 
 - Copy file `vars-template.sh` as `vars.sh`. The `Makefile` uses `vars.sh` to load your specific settings.
 
-    > Replace the value for `VEN_CLOUD_API_KEY` with the value of `apiKey` from your Venafi Control Plane tenant. 
+    > Replace the value for `CYBR_CLOUD_API_KEY` with the value of `apiKey` from your Venafi Control Plane tenant. 
 
-    > Replace the value for `VEN_ZONE_PRIVATE_CA` with the value of the issuing template path. If you don't know what this is, login to Venafi Control Plane, create a issuing template with Venafi BuiltIn CA and create an application. The ZONE is of the form application/issuing-template. Refer to Venafi Control Plane documention for details about how to create an application , assign ownership, etc. 
+    > Replace the value for `CYBR_ZONE_PRIVATE_CA` with the value of the issuing template path. If you don't know what this is, login to Venafi Control Plane, create a issuing template with Venafi BuiltIn CA and create an application. The ZONE is of the form application/issuing-template. Refer to Venafi Control Plane documention for details about how to create an application , assign ownership, etc. 
 
     > No other variables are required to be setup at this time. We will revisit the other variables as needed. 
 
 - Optionally copy `cloud-settings-template.sh` as `cloud-settings.sh`. This file is optionally included in the `Makefile` and you can use only if you want to automate things in Google Cloud
 - All commands from terminal will be executed from the `main` folder. After you clone the repo change the directory to `main` 
 
-- You have created the the required configurations and policies for Firefly to operate in cluster. This is a one time configuration that can be used across all your clusters. Refer to the section [Configuring Venafi Firefly](#configuring-venafi-firefly) to get started. 
+- You have created the required configurations and policies for Firefly to operate in cluster. This is a one time configuration that can be used across all your clusters. Refer to the section [Configuring Venafi Firefly](#configuring-venafi-firefly) to get started. 
 
 
 
@@ -33,9 +33,9 @@ The demos use a `Makefile` for all operations. Always review the target you are 
 Login into [Venafi TLS Protect Cloud](https://ui.venafi.cloud) If you don't have an account you can sign up for a 30 day trial.
 
 ### Creating a Team
-If you haven't already created a team and assiged members to it. 
+If you haven't already created a team and assigned members to it. 
 - Go to Settings / Teams
-- Click New and provide a name and role for the team. For eg, `platform-admin` and Role as `System Administrator`.  Make sure to assign membership. Set the team name in `vars.sh`. The name of the variable is `VEN_TEAM_NAME`
+- Click New and provide a name and role for the team. For eg, `platform-admin` and Role as `System Administrator`.  Make sure to assign membership. Set the team name in `vars.sh`. The name of the variable is `CYBR_TEAM_NAME`
 
 ### Creating a Sub CA Provider 
 The first step to getting started with **Firefly** is to create a subordinate CA provider. Several upstream CA's are supported but for the purposes of setting up this demo environment 
@@ -83,7 +83,7 @@ Similar to how we created a policy before create a new policy called `firefly-is
 | :---              |    :----:   | 
 | Validity   | 1 Hour        | 
 | Commmon Name      | `istiod.istio-system.svc`<br>`^.*`       |
-| DNS(SAN)   | `istio-csr.venafi.svc`<br>`cert-manager-istio-csr.venafi.svc`<br>`istiod.istio-system.svc`        | 
+| DNS(SAN)   | `istio-csr.cyberark.svc`<br>`cert-manager-istio-csr.cyberark.svc`<br>`istiod.istio-system.svc`        | 
 | URI Addresss (SAN)   | `^spiffe://cluster\.local/ns/.*/sa/.*`        | 
 | Key Constraint   | RSA 2048        | 
 | Key Usage   | Key Encipherment <br> Digital Signature        | 
@@ -144,18 +144,18 @@ Service account for certificate discovery
 Creating a new service account for the Venafi Kubernetes Agent
  ✅    Running prerequisite checks
 Service Account id=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-Service account was created successfully file=artifacts/venafi-install/venafi_agent_secret.json format=secret
+Service account was created successfully file=artifacts/cyberark-install/cybr_mis_agent_secret.json format=secret
 Creating Service Account in Venafi Control Plane for registry secret
 Creating a new service account for Venafi OCI registry
  ✅    Running prerequisite checks
 Service Account id=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
-Service account was created successfully file=artifacts/venafi-install/venafi_registry_secret.json format=secret scopes="[enterprise-cert-manager enterprise-approver-policy enterprise-venafi-issuer]"
+Service account was created successfully file=artifacts/cyberark-install/cybr_mis_registry_secret.json format=secret scopes="[cert-manager-components enterprise-approver-policy enterprise-venafi-issuer]"
 Creating Service account in Venafi Control Plane for Firefly
 Creating a new service account for the Venafi Firefly
  ✅    Running prerequisite checks
 Service Account id=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-Service account was created successfully file=artifacts/venafi-install/venafi_firefly_secret.json format=secret
-namespace/venafi created
+Service account was created successfully file=artifacts/cyberark-install/cybr_mis_firefly_secret.json format=secret
+namespace/cyberark created
 namespace/sandbox created
 Credentials for venafi registry
 secret/venafi-image-pull-secret created
@@ -181,7 +181,7 @@ make generate-venafi-manifests
 You will see an output that simply says 
 `Generating Venafi Helm manifests for installation` 
 
-Review the contents if you want to. The generated file is `artifacts/venafi-install/venafi-manifests.yaml` 
+Review the contents if you want to. The generated file is `artifacts/cyberark-install/venafi-manifests.yaml` 
 
 ### STEP 3
 
@@ -210,18 +210,18 @@ Once complete, you should see the following that confirms the installation
 ```
 UPDATED RELEASES:
 NAME                             NAMESPACE   CHART                                          VERSION   DURATION
-venafi-connection                venafi      venafi-charts/venafi-connection                v0.3.1          2s
-cert-manager                     venafi      venafi-charts/cert-manager                     v1.16.3        28s
-cert-manager-csi-driver          venafi      venafi-charts/cert-manager-csi-driver          v0.10.2         2s
-venafi-enhanced-issuer           venafi      venafi-charts/venafi-enhanced-issuer           v0.15.0        23s
-cert-manager-csi-driver-spiffe   venafi      venafi-charts/cert-manager-csi-driver-spiffe   v0.8.2         23s
-approver-policy-enterprise       venafi      venafi-charts/approver-policy-enterprise       v0.20.0        33s
-venafi-kubernetes-agent          venafi      venafi-charts/venafi-kubernetes-agent          1.4.0          41s
-firefly                          venafi      venafi-firefly/firefly                         v1.5.0         14s
-trust-manager                    venafi      venafi-charts/trust-manager                    v0.15.0        25s
+venafi-connection                cyberark    venafi-charts/venafi-connection                v0.3.1          2s
+cert-manager                     cyberark    venafi-charts/cert-manager                     v1.16.3        23s
+cert-manager-csi-driver          cyberark    venafi-charts/cert-manager-csi-driver          v0.10.2         0s
+venafi-enhanced-issuer           cyberark    venafi-charts/venafi-enhanced-issuer           v0.15.0        23s
+cert-manager-csi-driver-spiffe   cyberark    venafi-charts/cert-manager-csi-driver-spiffe   v0.8.2         29s
+approver-policy-enterprise       cyberark    venafi-charts/approver-policy-enterprise       v0.20.0        33s
+venafi-kubernetes-agent          cyberark    venafi-charts/venafi-kubernetes-agent          1.4.0          39s
+firefly                          cyberark    venafi-firefly/firefly                         v1.5.0         10s
+trust-manager                    cyberark    venafi-charts/trust-manager                    v0.15.0        27s
 ```
 
-All of the above components are installed and running in the `venafi` namespace in your cluster. `make install` uses `venctl` to install the components. By simply adding additional kubernetes contexts, you can install the same configuration on addtional clusters. 
+All of the above components are installed and running in the `cyberark` namespace in your cluster. `make install` uses `venctl` to install the components. By simply adding additional kubernetes contexts, you can install the same configuration on addtional clusters. 
 
 ### STEP 4
 
@@ -249,7 +249,7 @@ Creating an issuer. We will now create an issuer using the `ZONE` defined in `va
 ```
 make create-venafi-cloud-privateca-cluster-issuer 
 ```
-This will create a few new resources. A `VenafiConnection` resource and a `VenafiClusterIssuer` resource. The `VenafiConnection` resource will be in the `venafi` namespace and the cluster issuer is as the name suggests cluster scoped.
+This will create a few new resources. A `VenafiConnection` resource and a `VenafiClusterIssuer` resource. The `VenafiConnection` resource will be in the `cyberark` namespace and the cluster issuer is as the name suggests, cluster-scoped.
 The output you see will be 
 
 ```
@@ -305,10 +305,10 @@ kubectl get CertificateRequests -n sandbox
 The output will be
 
 ```
-NAME                                          APPROVED   DENIED   READY   ISSUER    REQUESTOR                                         AGE
-cert-hundred-days-1.svc.cluster.local-sbw7t   True                True    firefly   system:serviceaccount:venafi:cert-manager   3m
-cert-ten-days-1.svc.cluster.local-x6djj       True                True    firefly   system:serviceaccount:venafi:cert-manager   3m
-cert-two-days-1.svc.cluster.local-kjsqd       True                True    firefly   system:serviceaccount:venafi:cert-manager   3m
+NAME                                      APPROVED   DENIED   READY   ISSUER    REQUESTER                                     AGE
+cert-hundred-days-1.svc.cluster.local-1   True                True    firefly   system:serviceaccount:cyberark:cert-manager   25s
+cert-ten-days-1.svc.cluster.local-1       True                True    firefly   system:serviceaccount:cyberark:cert-manager   25s
+cert-two-days-1.svc.cluster.local-1       True                True    firefly   system:serviceaccount:cyberark:cert-manager   25s
 ```
 Note that the issuer is set to **firefly**
 
@@ -321,11 +321,11 @@ kubectl get secret cert-two-days-1.svc.cluster.local -n sandbox -o jsonpath="{.d
 to see
 
 ```
-        Issuer: C=US, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit, CN=firefly-1-20240426195248 firefly-built-in-180.svc.cluster.local
+        Issuer: C=US, ST=TX, L=Frisco, O=CyberArk Inc, OU=Firefly Unit, CN=firefly-1-20250208113912 firefly-built-in-180.svc.cluster.local
         Validity
-            Not Before: Apr 27 01:09:17 2024 GMT
-            Not After : Apr 29 01:09:17 2024 GMT
-        Subject: C=USA, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit 3, CN=cert-two-days-1.svc.cluster.local
+            Not Before: Feb  8 17:42:03 2025 GMT
+            Not After : Feb 10 17:42:03 2025 GMT
+        Subject: C=USA, ST=MA, L=Newton, O=CyberArk Inc, OU=Firefly Unit 3, CN=cert-two-days-1.svc.cluster.local
 ```
 
 Run the following, 
@@ -335,11 +335,11 @@ kubectl get secret cert-ten-days-1.svc.cluster.local -n sandbox -o jsonpath="{.d
 
 to see 
 ```
-        Issuer: C=US, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit, CN=firefly-1-20240426195248 firefly-built-in-180.svc.cluster.local
+        Issuer: C=US, ST=TX, L=Frisco, O=CyberArk Inc, OU=Firefly Unit, CN=firefly-1-20250208113912 firefly-built-in-180.svc.cluster.local
         Validity
-            Not Before: Apr 27 01:09:17 2024 GMT
-            Not After : May  7 01:09:17 2024 GMT
-        Subject: C=USA, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit 2, CN=cert-ten-days-1.svc.cluster.local
+            Not Before: Feb  8 17:42:03 2025 GMT
+            Not After : Feb 18 17:42:03 2025 GMT
+        Subject: C=USA, ST=MA, L=Newton, O=CyberArk Inc, OU=Firefly Unit 2, CN=cert-ten-days-1.svc.cluster.local
 ```
 
 Run the following
@@ -348,11 +348,11 @@ kubectl get secret cert-hundred-days-1.svc.cluster.local -n sandbox -o jsonpath=
 ```
 to see
 ```
-        Issuer: C=US, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit, CN=firefly-1-20240426195248 firefly-built-in-180.svc.cluster.local
+        Issuer: C=US, ST=TX, L=Frisco, O=CyberArk Inc, OU=Firefly Unit, CN=firefly-1-20250208113912 firefly-built-in-180.svc.cluster.local
         Validity
-            Not Before: Apr 27 01:09:17 2024 GMT
-            Not After : Aug  5 01:09:17 2024 GMT
-        Subject: C=USA, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit 1, CN=cert-hundred-days-1.svc.cluster.local
+            Not Before: Feb  8 17:42:03 2025 GMT
+            Not After : May 19 17:42:03 2025 GMT
+        Subject: C=USA, ST=MA, L=Newton, O=CyberArk Inc, OU=Firefly Unit 1, CN=cert-hundred-days-1.svc.cluster.local
 ```
 
 ## Access the Venafi Control Plane to view the Issuer Certificates and the associated metrics
@@ -374,8 +374,8 @@ This will create a few secrets, few certificates and a few pods in the `sandbox`
 
 If you are operating in a cluster where you may already have a certificates, you don't need to seed any sample data. The purpose of this step is to demonstrate the Venafi discovery capabilities. 
 One of the service accounts that we created during the initial step was to setup the discovery of certificates from clusters. 
-After about couple of minutes or so login to the UI and access "Installtions / Kubernetes Clusters".
-You should see a cluster registered as `demo-cluster-<random number>` 
+After about couple of minutes or so login to the UI and access "Installations / Kubernetes Clusters".
+You should see a cluster registered as `mis-demo-cluster-<random number>` 
 
 Click on the cluster name and then click `View Certificates`. Pick one of the certificates, For eg. `cipher-snake.svc.cluster.local` and click on it. Review the details. You will notice that the Key size is likely non-compliant. Review the `Installations` by clicking on it. Expand the cluster resources to find that this certificate is actually in use in a workload and it's lifecycle is not managed at all. 
 
@@ -413,17 +413,17 @@ issuer.firefly.venafi.com/firefly-mesh-wi-issuer created
 ### STEP 2
 istio-csr requires a trust anchor that needs to be mounted when installed. The reference to `root-cert.pem` in [templates/helm/istio-csr-values.yaml](templates/helm/istio-csr-values.yaml) is for the trust anchor. 
 
-Before you run the target for `step2` review the target `make-step2`. This target calls another target called `_create_sourceCA`. The variable `VEN_TRUST_ANCHOR_ROOT_CA_PEM` should be set in the `vars.sh`. The value will be a path to a PEM file that acts as the trust anchor. The referred PEM file does not exist in the repo. You will need to create it. 
+Before you run the target for `step2` review the target `make-step2`. This target calls another target called `_create_sourceCA`. The variable `CYBR_TRUST_ANCHOR_ROOT_CA_PEM` should be set in the `vars.sh`. The value will be a path to a PEM file that acts as the trust anchor. The referred PEM file does not exist in the repo. You will need to create the PEM file. You can populate the contents of this file by accessing Venafi Control Plane and downloading the CA. For this demo it will be the root of venafi built in CA. 
 
 Run 
 ```
 make mesh-step2
 ```
 
-Running the target produces the below output. A trust-manager managed `Bundle` called `venafi-firefly-trust-anchor` is created that is automatically managed. `istio-csr` uses the `Bundle` and will make it automatically available if/when `secret/venafi-trust-anchor` changes.  
+Running the target produces the below output. A trust-manager managed `Bundle` called `istio-ca-root-cert` is created that is automatically managed. `istio-csr` uses the `Bundle` and will make it automatically available when `secret/cyberark-trust-anchor` changes.  
 ```
 ❯ make mesh-step2
-secret/venafi-trust-anchor created
+secret/cyberark-trust-anchor created
 Creating Firefly trust anchor
 configmap/istio-csr-ca created
 bundle.trust.cert-manager.io/istio-ca-root-cert created
@@ -431,15 +431,17 @@ bundle.trust.cert-manager.io/istio-ca-root-cert created
 Review the `Bundle` by simply running, 
 
 ```
-kubectl describe Bundle -n istio-system 
+kubectl describe Bundle istio-ca-root-cert -n istio-system 
 ```
 and you will see 
 
 ```
+...
+...
 Events:
-  Type    Reason  Age    From     Message
-  ----    ------  ----   ----     -------
-  Normal  Synced  2m47s  bundles  Successfully synced Bundle to namespaces that match this label selector: issuer=venafi-firefly
+  Type    Reason  Age   From     Message
+  ----    ------  ----  ----     -------
+  Normal  Synced  29s   bundles  Successfully synced Bundle to namespaces that match this label selector: issuer=cyberark-firefly
 ```
 
 ### STEP 3
@@ -456,37 +458,37 @@ Generating Venafi Helm manifests for installing istio-csr
 ........
 UPDATED RELEASES:
 NAME                     NAMESPACE   CHART                                  VERSION   DURATION
-cert-manager             venafi      venafi-charts/cert-manager             v1.16.3         2s
-cert-manager-istio-csr   venafi      venafi-charts/cert-manager-istio-csr   v0.14.0        16s
+cert-manager             cyberark    venafi-charts/cert-manager             v1.16.3         2s
+cert-manager-istio-csr   cyberark    venafi-charts/cert-manager-istio-csr   v0.14.0        14s
 ```
 
 Validate that all the components are running using
 ```
-kubectl get pods -n venafi
+kubectl get pods -n cyberark
 ```
 and you should see 
 
 ```
-NAME                                                      READY   STATUS    RESTARTS      AGE
-cert-manager-approver-policy-6cc4f596c-gztv8              1/1     Running   0             14m
-cert-manager-cainjector-67bdf7bdd6-b5tm7                  1/1     Running   0             15m
-cert-manager-cc756548f-5l6qk                              1/1     Running   0             15m
-cert-manager-csi-driver-cnxnb                             3/3     Running   1 (14m ago)   14m
-cert-manager-csi-driver-spiffe-approver-7b5df6bb7-xv6nb   1/1     Running   0             14m
-cert-manager-csi-driver-spiffe-driver-fnbzd               3/3     Running   1 (13m ago)   14m
-cert-manager-istio-csr-794cd6dfb9-dcvbr                   1/1     Running   0             12m
-cert-manager-webhook-67cbd84cc9-bb28q                     1/1     Running   0             15m
-firefly-54c68867c9-dlvgn                                  1/1     Running   0             13m
-firefly-54c68867c9-kht84                                  1/1     Running   0             13m
-trust-manager-7bc6c6cc6-z65v8                             1/1     Running   0             13m
-venafi-enhanced-issuer-69c56f45f-9g6nr                    1/1     Running   0             14m
-venafi-enhanced-issuer-69c56f45f-fq497                    1/1     Running   0             14m
-venafi-kubernetes-agent-58d748cd57-lsxbz                  1/1     Running   0             14m
+NAME                                                      READY   STATUS    RESTARTS        AGE
+cert-manager-7b5fbf4c8c-xtq6p                             1/1     Running   0               10m
+cert-manager-approver-policy-86c9f87b69-lds9m             1/1     Running   0               10m
+cert-manager-cainjector-7bdb4b49fb-nzsq2                  1/1     Running   0               10m
+cert-manager-csi-driver-9wrcz                             3/3     Running   1 (9m28s ago)   10m
+cert-manager-csi-driver-spiffe-approver-7b5df6bb7-8g4tk   1/1     Running   0               10m
+cert-manager-csi-driver-spiffe-driver-wgfhj               3/3     Running   0               10m
+cert-manager-istio-csr-67555f88f-x79xx                    1/1     Running   0               69s
+cert-manager-webhook-67cbd84cc9-sr5rl                     1/1     Running   0               10m
+firefly-54c68867c9-4d266                                  1/1     Running   0               9m24s
+firefly-54c68867c9-vjfkz                                  1/1     Running   0               9m24s
+trust-manager-ffc4dd9f8-7zpv9                             1/1     Running   0               9m23s
+venafi-enhanced-issuer-69c56f45f-m55pz                    1/1     Running   0               10m
+venafi-enhanced-issuer-69c56f45f-wgjc5                    1/1     Running   0               10m
+venafi-kubernetes-agent-f874f6774-hr7tx                   1/1     Running   0               10m
 ```
 
-Additionally, this also creates the `istiod-dynamic` certificate that will be bootstrapped to Istio
+The `istio-csr` installation automatically creates a new certificate called `istiod-dynamic`  that will be bootstrapped to Istio for signing all mesh workloads
 
-Review the certificate created by Firefly for Istio by running
+Review the certificate issued by Fireflyfor Istio by running
 ```
 kubectl get certificate istiod-dynamic -n istio-system
 ```
@@ -496,17 +498,17 @@ You can additonally inspect the secret bootstrapped to Istio by running
 ```
 and you should see 
 ```
-        Issuer: C=US, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit, CN=firefly-1-20250124103526 firefly-built-in-180.svc.cluster.local
+        Issuer: C=US, ST=TX, L=Frisco, O=CyberArk Inc, OU=Firefly Unit, CN=firefly-1-20250208113912 firefly-built-in-180.svc.cluster.local
         Validity
-            Not Before: Jan 24 16:37:14 2025 GMT
-            Not After : Jan 24 17:37:14 2025 GMT
+            Not Before: Feb  8 17:47:31 2025 GMT
+            Not After : Feb  8 18:47:31 2025 GMT
         Subject: CN=istiod.istio-system.svc
 ```
 This is the `istiod` secret that Istio will use for signing all incoming mesh workloads. 
 
 ### STEP 4
 
-We will now install Istio by running the following. Istio is installed using the `IstioOperator` . The file is located at [templates/servicemesh/istio-config.yaml](templates/servicemesh/istio-config.yaml) for review. Note the `caAddress` and the setting for `CA_SERVER`. The `caAddress` points to `istio-csr` service and the built in `CA_SERVER` is turned off. 
+We will now install Istio by running the following. Istio is installed using the `IstioOperator` . The file is located at [templates/servicemesh/istio-config.yaml](templates/servicemesh/istio-config.yaml) for review. Note the `caAddress` and the setting for `CA_SERVER`. The `caAddress` points to `istio-csr` service and the built in `CA_SERVER` is turned off. The `caAddress` needs to be correctly pointing for Istio to work with `istio-csr`
 
 Run 
 ```
@@ -543,84 +545,142 @@ NAME     MODE     AGE
 global   STRICT   55s
 ```
 
-### STEP 6 - **Optional**
-While all the mesh workloads will use **Firefly** for their identities, we also need a public certificate to access the Ingress Gateway. The sample application that we will eventually deploy will be accessed from the browser. Venafi will issue a public certificate that is trusted by the browser. The certificate will be issued by a `VenafiClusterIssuer`. 
-The template for issuer is located here [templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml](templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml) 
-The template for certificate is located here [templates/cloud/venafi-cloud-managed-public-cert.yaml](templates/cloud/venafi-cloud-managed-public-cert.yaml)
+### STEP 6
+With all the components installed in cluster and istio configured to use Firefly issued certificate for signing mesh workloads, let's deploy a sample app. You can choose to install your own sample app into `mesh-apps` namespace by ignoring this step. In this demo we will install a custom swag store application. 
 
-If you don't need to attach a certificate for your Gateway you can ignore this step.
-
-There are two options for this step. Either using Venafi Cloud or the data center to issue a public certificate. You are also required to set the variable `VEN_ZONE_PUBLIC_CA` and `VEN_DOMAIN_FOR_SAMPLE_APP` The Zone is used for issuing a publicly trusted certificate. You can issue a private certificate if your browser configured to trust the CA. The DNS will be used to configured the Gateway.  The target to get a certificate from Venafi cloud is `mesh-step6-cloud` and from data center is `mesh-step6-tpp`
-
-Run 
-```
-make mesh-step6-cloud
-```
-to create an issuer and certificate. You will see the following output 
-```
-❯ make mesh-step6-cloud
-venaficlusterissuer.jetstack.io/venafi-publicca-cluster-issuer created
-certificate.cert-manager.io/5419352604.example.com created
-```
-
-### STEP7 - **Optional**
-This is an optional step and will require you to adapt depending on where your cluster is running and if you need create a DNS entry to access the gateway. 
-This demo is setup on GKE with loadbalancer / domains managed by GCP. If this is not applicable to you, review the target and create appropriate DNS entries. 
-You are also **REQUIRED** to setup `cloud-settings.sh` and configure your Google Project settings.  
-
-Basically, you need to run 
-```
-kubectl get svc istio-ingressgateway -n istio-system
-```
-and associate the provisioned loadblancer IP/hostname to your DNS. 
-**If you are not using Google Cloud, skip this step. 
-To automatically do that in Google Cloud for a domain you own, just run
-```
-make mesh-step7
-```
-
-### STEP 8
-It's time to deploy a sample application. The sample application will be deployed in a namespace called `mesh-apps`. 
 Run
 ```
-make mesh-step8
+make mesh-step6
 ```
-
-Validate that the sample app is deployed. Run ,
+This will install a sample app in the `mesh-apps` namespace. It will take a few minutes for all the pods to be deployed and go into `Running` state. Validate that all the pods are deployed and running by simply running 
 ```
 kubectl get pods -n mesh-apps
 ```
-to see
+and you will see the following. Note that all pods have 2 containers as this namespace has a label `istio-injection=enabled`
+
 ```
-NAME                             READY   STATUS    RESTARTS   AGE
-details-v1-698d88b-7jbpw         2/2     Running   0          29s
-productpage-v1-675fc69cf-lczlb   2/2     Running   0          29s
-ratings-v1-6484c4d9bb-gxf48      2/2     Running   0          29s
-reviews-v1-5b5d6494f4-j754q      2/2     Running   0          29s
-reviews-v2-5b667bcbf8-mlvhm      2/2     Running   0          29s
-reviews-v3-5b9bd44f4-cs8bx       2/2     Running   0          29s
+NAME                                     READY   STATUS    RESTARTS   AGE
+adservice-8744f64bd-bbmz2                2/2     Running   0          62s
+cartservice-6bc9b49975-4sq2m             2/2     Running   0          62s
+checkoutservice-66965f79db-cb8nr         2/2     Running   0          62s
+currencyservice-74bcdd8c58-2rnmn         2/2     Running   0          61s
+emailservice-848bd6c94d-mbdsh            2/2     Running   0          61s
+frontend-64776cfd7f-6s8bw                2/2     Running   0          61s
+paymentservice-7f658cdf44-pbg5r          2/2     Running   0          61s
+productcatalogservice-78d5ffb44d-vgk7f   2/2     Running   0          61s
+recommendationservice-7bc9cf9d4-jfzp8    2/2     Running   0          60s
+redis-cart-777db56c5f-th8cw              2/2     Running   0          60s
+shippingservice-7ddbb47576-n7c26         2/2     Running   0          60s
 ```
 
-Let's validate that the certificates issued to all the mesh workloads are indeed issued by **Firefly**
-
+As we also configured **Firefly** to issue all certs, let's inspect what the certificate in the workload looks like. 
 Run
 ```
 make print-svid
 ```
-`print-svid` is a target that prints the cert assoicated with ratings. You can choose to change the script to look at other certificates as well. You will see an output similar to below
-
+to see 
 ```
-❯ make print-svid
-Pod name is ratings-v1-6484c4d9bb-gxf48 
+Pod name is frontend-7d9b98c747-bxb9d 
 Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            37:1d:14:4e:e5:92:30:c6:35:0b:6c:98:92:56:89:c5
+            42:86:b7:92:a3:26:bf:00:b4:cd:26:c5:83:39:e7:c9
         Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=US, ST=TX, L=Frisco, O=Venafi Inc, OU=Firefly Unit, CN=firefly-1-20250124103526 firefly-built-in-180.svc.cluster.local
+        Issuer: C=US, ST=TX, L=Frisco, O=CyberArk Inc, OU=Firefly Unit, CN=firefly-1-20250208113912 firefly-built-in-180.svc.cluster.local
         Validity
-            Not Before: Jan 24 16:38:31 2025 GMT
-            Not After : Jan 24 17:38:31 2025 GMT
+            Not Before: Feb  8 22:27:47 2025 GMT
+            Not After : Feb  8 23:27:47 2025 GMT
+        .....
+        .....
+             X509v3 Subject Alternative Name: 
+                URI:spiffe://cluster.local/ns/mesh-apps/sa/frontend      
+        .....
 ```
-The mesh identity is valid for 1 hour as defined by a policy in the Venafi Control Plane. Access Venafi Control Plane and the dashboard to review the metrics associated with this issuer. 
+
+Note that the Issuer for the workload is **Firefly** and the accessing the UI will provide you addition information. The mesh identity is valid for 1 hour as defined by a policy in the Venafi Control Plane. Access Venafi Control Plane and the dashboard to review the metrics associated with this issuer. 
+
+Test the app by simply running 
+
+```
+kubectl -n mesh-apps port-forward service/frontend 8120:80
+```
+and access the application on your browser as `http://localhost:8120`
+
+## Optional Steps
+
+### STEP 7 **Optional**
+Optionally, add istio tools Kiali, Grafana and Prometheus to your installation. Run
+
+```
+make mesh-step7
+```
+and you should see kiali , prometheus and grafana installed in the `istio-system` namespace. You can access kiali by running `istioctl dashboard kiali` to look at the traffic, the workload identities , etc. 
+
+
+### STEP 8 - **Optional**
+If you prefer to access the sample application with a DNS that you can configure and access instead of doing a port-forward and using local host, we will need to configure the Istio Gateway resources. We also need a public certificate to access the Ingress Gateway. Venafi will issue a public certificate that is trusted by the browser. The certificate will be issued by a `VenafiClusterIssuer`. 
+The template for issuer is located here [templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml](templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml) 
+The template for certificate is located here [templates/cloud/venafi-cloud-managed-public-cert.yaml](templates/cloud/venafi-cloud-managed-public-cert.yaml)
+
+There are two options for this step. Either using Venafi Cloud or the data center to issue a public certificate. You are also required to set the variable `CYBR_ZONE_PUBLIC_CA` and `CYBR_DOMAIN_FOR_SAMPLE_APP` The Zone is used for issuing a publicly trusted certificate. You can issue a private certificate if your browser configured to trust the CA. The DNS will be used to configured the Gateway.  The target to get a certificate from Venafi cloud is `mesh-step8-cloud` and from data center is `mesh-step8-tpp`
+
+Run 
+```
+make mesh-step8-cloud
+```
+to create an issuer and certificate. You will see the following output 
+```
+❯ make mesh-step8-cloud
+venaficlusterissuer.jetstack.io/venafi-publicca-cluster-issuer created
+certificate.cert-manager.io/5419352604.example.com created
+```
+
+### STEP9- **Optional**
+If you have completed STEP8 that means you have access to a valid DOMAIN and can add a record set. The demo is scripted to run `aws/map-dns-to-gateway.sh` Review the script and change it as you see fit. 
+You will notice that the script retrieves the IP address from the ingress gateway service. Some environments will provide you a hostname and not ip. 
+You are also **REQUIRED** to setup `cloud-settings.sh` and configure your AWS Route53 settings. Make sure you are authenticated to the account where you intend to add a DNS record. 
+
+If you are to manually perform this step, basically, you need to run 
+```
+kubectl get svc istio-ingressgateway -n istio-system
+```
+and associate the provisioned loadblancer IP/hostname to your DNS. 
+To automatically add an entry to AWS Rout53 for a domain you have access to, just run
+```
+make mesh-step9
+```
+and you will see
+
+```
+Create DNS entry for 3018580802.example.com to map to Gateway host/ip
+Zone is AAAABBBBCCCCDDDD
+DNS is 3018580802.example.com
+{
+    "ChangeInfo": {
+        "Id": "/change/C064230619T9XHRGPQ6CF",
+        "Status": "PENDING",
+        "SubmittedAt": "2025-02-09T01:41:27.515000+00:00"
+    }
+}
+```
+
+### STEP 10 - **Optional**
+If you have completed STEPS  8 and 9, you can create the required gateway resources. The gateway resource template is located here [templates/servicemesh/sample-app-gateway.yaml](templates/servicemesh/sample-app-gateway.yaml) Review the file. This will be used for creating a gateway resource that is mapped to the frontend sample service.
+
+Run 
+```
+make mesh-step10
+```
+and you will see
+```
+gateway.networking.istio.io/storefront-gateway created
+virtualservice.networking.istio.io/storefront-virtualservice created
+serviceentry.networking.istio.io/allow-egress-googleapis created
+serviceentry.networking.istio.io/allow-egress-google-metadata created
+virtualservice.networking.istio.io/frontend created
+####################################################################################################
+######### Sample apps takes about 60 seconds before pods are Ready in mesh-apps namespace ##########
+######### Access application using https://3018580802.example.com/     ###
+####################################################################################################
+```

--- a/main/cloud-settings-template.sh
+++ b/main/cloud-settings-template.sh
@@ -1,19 +1,19 @@
-export VEN_CLUSTER_NAME :=ven-demo-cluster01
-export VEN_DOMAIN_NAME :=REPLACE_WITH_DOMAIN_YOU_HAVE_ACCESS_TO
+export CYBR_CLUSTER_NAME :=ven-demo-cluster01
+export CYBR_DOMAIN_NAME :=REPLACE_WITH_DOMAIN_YOU_HAVE_ACCESS_TO
 
 #GCP Specific Settings 
-export VEN_GCP_PROJECT_ID :=REPLACE_WITH_GOOGLE_PROJECT_ID
-export VEN_GCP_REGION :=us-central1
+export CYBR_GCP_PROJECT_ID :=REPLACE_WITH_GOOGLE_PROJECT_ID
+export CYBR_GCP_REGION :=us-central1
 
 #GCP DNS Specific variables
-export VEN_GCP_ZONE :=REPLACE_WITH_GCP_DNS_ZONE
+export CYBR_GCP_ZONE :=REPLACE_WITH_GCP_DNS_ZONE
 
 
 #GCP Google CAS Specific Settings 
-export VEN_GCP_CAS_POOL_TIER :=devops
-export VEN_GCP_CAS_POOL_NAME :=ven-demo-ca-pool-devops
-export VEN_GCP_CAS_NAME :=ven-demo-cas-apr-10-2024-1
+export CYBR_GCP_CAS_POOL_TIER :=devops
+export CYBR_GCP_CAS_POOL_NAME :=ven-demo-ca-pool-devops
+export CYBR_GCP_CAS_NAME :=ven-demo-cas-apr-10-2024-1
 
 #AWS Specific Variables
-export VEN_AWS_PROFILE_NAME :=foo #set to none to use default
-export VEN_AWS_REGION :=us-east-1
+export CYBR_AWS_PROFILE_NAME :=foo #set to none to use default
+export CYBR_AWS_REGION :=us-east-1

--- a/main/create-cluster.sh
+++ b/main/create-cluster.sh
@@ -1,7 +1,7 @@
 curr_date=$(date +%S%H%M%d%m)
-echo Creating cluster demo-poc-cluster-$curr_date
+echo Creating cluster mis-demo-cluster-$curr_date
 
-cat <<EOF | kind create cluster --name demo-poc-cluster-$curr_date --config=-
+cat <<EOF | kind create cluster --name mis-demo-cluster-$curr_date --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/main/namespaces/cyberark.yaml
+++ b/main/namespaces/cyberark.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: venafi
+  name: cyberark
   labels:
-     issuer: venafi-firefly  
+     issuer: cyberark-firefly  

--- a/main/samples/cert-policy-and-rbac-self-signed.yaml
+++ b/main/samples/cert-policy-and-rbac-self-signed.yaml
@@ -86,8 +86,8 @@ subjects:
 # The users who should be bound to the policies defined.
 - kind: ServiceAccount
   name: cert-manager-csi-driver
-  namespace: venafi
+  namespace: cyberark
 - kind: ServiceAccount
   name: cert-manager
-  namespace: venafi
+  namespace: cyberark
 

--- a/main/templates/certs/02-expiry-eddie-cert.yaml
+++ b/main/templates/certs/02-expiry-eddie-cert.yaml
@@ -8,13 +8,13 @@ spec:
   duration: 2184h
   subject:
     organizations: 
-     - Venafi Inc
+     - CyberArk Inc
     organizationalUnits:
-     - TLSPK Demo
+     - MIS Demo
     localities:
-     - Salt Lake City
+     - Newton
     provinces:
-     - Utah
+     - MA
     countries:
      - US
   privateKey:

--- a/main/templates/certs/04-ghost-rider-cert.yaml
+++ b/main/templates/certs/04-ghost-rider-cert.yaml
@@ -8,13 +8,13 @@ spec:
   duration: 2184h
   subject:
     organizations: 
-     - Venafi Inc
+     - CyberArk Inc
     organizationalUnits:
-     - TLSPK Demo
+     - MIS Demo
     localities:
-     - Salt Lake City
+     - Newton
     provinces:
-     - Utah
+     - MA
     countries:
      - US
   privateKey:

--- a/main/templates/certs/sample-cert.yaml
+++ b/main/templates/certs/sample-cert.yaml
@@ -8,13 +8,13 @@ spec:
   duration: 96h
   subject:
     organizations: 
-     - Venafi Inc
+     - CyberArk Inc
     organizationalUnits:
-     - TLSPK Demo
+     - MIS Demo
     localities:
-     - Salt Lake City
+     - Newton
     provinces:
-     - Utah
+     - MA
     countries:
      - US
   privateKey:

--- a/main/templates/cloud/venafi-cloud-connection.yaml
+++ b/main/templates/cloud/venafi-cloud-connection.yaml
@@ -2,10 +2,10 @@ apiVersion: jetstack.io/v1alpha1
 kind: VenafiConnection
 metadata:
   name: venafi-connection
-  namespace: venafi
+  namespace: cyberark
 spec:
   vaas:
-#    url: ${VEN_SERVER_URL}
+#    url: ${CYBR_SERVER_URL}
     apiKey:
     - secret:
         name: venafi-cloud-credentials

--- a/main/templates/cloud/venafi-cloud-managed-public-cert.yaml
+++ b/main/templates/cloud/venafi-cloud-managed-public-cert.yaml
@@ -1,16 +1,27 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
+  name: REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
   namespace: istio-system
 spec:
-  secretName: REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
+  secretName: REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
   duration: 72h
   privateKey:
     rotationPolicy: Always
+  subject:
+    organizations: 
+     - CyberArk Inc
+    organizationalUnits:
+     - MIS Demo
+    localities:
+     - Newton
+    provinces:
+     - MA
+    countries:
+     - US
   dnsNames:
-    - REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
-  commonName: REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
+    - REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
+  commonName: REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
   issuerRef:
     name: venafi-publicca-cluster-issuer
     kind: "VenafiClusterIssuer"

--- a/main/templates/cloud/venafi-cloud-privateca-cluster-issuer.yaml
+++ b/main/templates/cloud/venafi-cloud-privateca-cluster-issuer.yaml
@@ -5,5 +5,5 @@ metadata:
   name: venafi-privateca-cluster-issuer
 spec:
   venafiConnectionName: venafi-connection
-  zone: ${VEN_ZONE_PRIVATE_CA}
+  zone: ${CYBR_ZONE_PRIVATE_CA}
 ---

--- a/main/templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml
+++ b/main/templates/cloud/venafi-cloud-publicca-cluster-issuer.yaml
@@ -5,5 +5,5 @@ metadata:
   name: venafi-publicca-cluster-issuer
 spec:
   venafiConnectionName: venafi-connection
-  zone: ${VEN_ZONE_PUBLIC_CA}
+  zone: ${CYBR_ZONE_PUBLIC_CA}
 ---

--- a/main/templates/cloud/venafi-cloud-secret.yaml
+++ b/main/templates/cloud/venafi-cloud-secret.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: venafi-cloud-credentials
-  namespace: venafi
+  namespace: cyberark
 stringData:
-  venafi-cloud-key: ${VEN_CLOUD_API_KEY}
+  venafi-cloud-key: ${CYBR_CLOUD_API_KEY}

--- a/main/templates/common/cert-policy-and-rbac.yaml
+++ b/main/templates/common/cert-policy-and-rbac.yaml
@@ -113,7 +113,7 @@ subjects:
 # The users who should be bound to the policies defined.
 - kind: ServiceAccount
   name: cert-manager
-  namespace: venafi
+  namespace: cyberark
 - kind: ServiceAccount
   name: cert-manager-istio-csr
-  namespace: venafi
+  namespace: cyberark

--- a/main/templates/common/venafi-connection-rbac.yaml
+++ b/main/templates/common/venafi-connection-rbac.yaml
@@ -24,5 +24,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: venafi-connection
-  namespace: venafi
+  namespace: cyberark
 ---

--- a/main/templates/dc/venafi-tpp-connection.yaml
+++ b/main/templates/dc/venafi-tpp-connection.yaml
@@ -2,10 +2,10 @@ apiVersion: jetstack.io/v1alpha1
 kind: VenafiConnection
 metadata:
   name: venafi-connection
-  namespace: venafi
+  namespace: cyberark
 spec:
   tpp:
-    url: ${VEN_SERVER_URL}
+    url: ${CYBR_SERVER_URL}
     accessToken:
     - secret:
         name: venafi-tpp-credentials

--- a/main/templates/dc/venafi-tpp-managed-public-cert.yaml
+++ b/main/templates/dc/venafi-tpp-managed-public-cert.yaml
@@ -1,16 +1,16 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
+  name: REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
   namespace: istio-system
 spec:
-  secretName: REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
+  secretName: REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
   duration: 72h
   privateKey:
     rotationPolicy: Always
   dnsNames:
-    - REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
-  commonName: REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}
+    - REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
+  commonName: REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}
   issuerRef:
     name: venafi-publicca-cluster-issuer
     kind: "VenafiClusterIssuer"

--- a/main/templates/dc/venafi-tpp-privateca-cluster-issuer.yaml
+++ b/main/templates/dc/venafi-tpp-privateca-cluster-issuer.yaml
@@ -5,5 +5,5 @@ metadata:
   name: venafi-privateca-cluster-issuer
 spec:
   venafiConnectionName: venafi-connection
-  zone: ${VEN_ZONE_PRIVATE_CA}
+  zone: ${CYBR_ZONE_PRIVATE_CA}
 ---

--- a/main/templates/dc/venafi-tpp-publicca-cluster-issuer.yaml
+++ b/main/templates/dc/venafi-tpp-publicca-cluster-issuer.yaml
@@ -5,5 +5,5 @@ metadata:
   name: venafi-publicca-cluster-issuer
 spec:
   venafiConnectionName: venafi-connection
-  zone: ${VEN_ZONE_PUBLIC_CA}
+  zone: ${CYBR_ZONE_PUBLIC_CA}
 ---

--- a/main/templates/dc/venafi-tpp-secret.yaml
+++ b/main/templates/dc/venafi-tpp-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: venafi-tpp-credentials
-  namespace: venafi
+  namespace: cyberark
 stringData:
-  access-token: ${VEN_ACCESS_TOKEN}
+  access-token: ${CYBR_ACCESS_TOKEN}
 ---

--- a/main/templates/helm/istio-csr-values.yaml
+++ b/main/templates/helm/istio-csr-values.yaml
@@ -106,7 +106,7 @@ app:
     # presented to istio-agents. istio-agents must route to istio-csr using one
     # of these DNS names.
     certificateDNSNames:
-    - cert-manager-istio-csr.venafi.svc
+    - cert-manager-istio-csr.cyberark.svc
     # Requested duration of gRPC serving certificate. Will be automatically
     # renewed.
     # Based on NIST 800-204A recommendations (SM-DR13).

--- a/main/templates/servicemesh/firefly-trust-anchor.yaml
+++ b/main/templates/servicemesh/firefly-trust-anchor.yaml
@@ -9,7 +9,7 @@ spec:
   # those issued by Let's Encrypt, Google, Amazon and others.
   #- useDefaultCAs: true  
   - secret:
-      name: "venafi-trust-anchor"
+      name: "cyberark-trust-anchor"
       key: "root-cert.pem"
   target:
     # Data synced to the ConfigMap `my-org.com` or your private CA root at the key `ca.crt` in
@@ -18,4 +18,4 @@ spec:
       key: "root-cert.pem"
     namespaceSelector:
       matchLabels:
-         issuer: "venafi-firefly"
+         issuer: "cyberark-firefly"

--- a/main/templates/servicemesh/istio-config.yaml
+++ b/main/templates/servicemesh/istio-config.yaml
@@ -11,7 +11,7 @@ spec:
   values:
     global:
       # Change certificate provider to cert-manager istio agent for istio agent
-      caAddress: cert-manager-istio-csr.venafi.svc:443
+      caAddress: cert-manager-istio-csr.cyberark.svc:443
   components:
     pilot:
       k8s:

--- a/main/templates/servicemesh/sample-app-gateway.yaml
+++ b/main/templates/servicemesh/sample-app-gateway.yaml
@@ -16,9 +16,9 @@ spec:
       mode: SIMPLE
       serverCertificate: "sds"
       privateKey: "sds"
-      credentialName: "REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}"
+      credentialName: "REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}"
     hosts:
-    - "REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}"
+    - "REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}"
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -26,7 +26,7 @@ metadata:
   name: storefront-virtualservice
 spec:
   hosts:
-  - "REPLACE_WITH_SUB_DOMAIN.${VEN_DOMAIN_FOR_SAMPLE_APP}"
+  - "REPLACE_WITH_SUB_DOMAIN.${CYBR_DOMAIN_FOR_SAMPLE_APP}"
   gateways:
   - storefront-gateway
   http:

--- a/main/vars-template.sh
+++ b/main/vars-template.sh
@@ -1,26 +1,26 @@
 # Env settings to access Venafi
 
-export VEN_CLOUD_API_KEY :=REPLACE_WITH_CLOUD_API_KEY
-export VEN_ZONE_PRIVATE_CA :="Cloud App\\venafi-builtin" # E.g. Certificates\\Private-CA OR Venafi Cloud App\\issuing-template 
-export VEN_TEAM_NAME :=platform-admin
+export CYBR_CLOUD_API_KEY :=REPLACE_WITH_CLOUD_API_KEY
+export CYBR_ZONE_PRIVATE_CA :="Cloud App\\venafi-builtin" # E.g. Certificates\\Private-CA OR Venafi Cloud App\\issuing-template 
+export CYBR_TEAM_NAME :=platform-admin
 
 ##### BEGIN Required only if using data center ######
-export VEN_SERVER_URL :=https://venafi.example.com/vedsdk
-export VEN_ACCESS_TOKEN :=REPLACE_WITH_TPP_ACCESS_TOKEN
+export CYBR_SERVER_URL :=https://venafi.example.com/vedsdk
+export CYBR_ACCESS_TOKEN :=REPLACE_WITH_TPP_ACCESS_TOKEN
 # If using Data center and server uses a private CA.
-export VEN_TPP_CA_BUNDLE_PEM_FILE :=./venafi-tpp-server-ca.pem
+export CYBR_TPP_CA_BUNDLE_PEM_FILE :=./venafi-tpp-server-ca.pem
 ##### END Required only if using data center ######
 
 
 ### BEGIN - Required only for service mesh usecase #####
-export VEN_ZONE_PUBLIC_CA :="My-Apps\\public-ca" # E.g. TPP-Certificates\\\\Public-CA OR Venafi Cloud App\\issuing-template 
-export VEN_DOMAIN_FOR_SAMPLE_APP :=example.com
-export VEN_AWS_ZONE :=foobar
+export CYBR_ZONE_PUBLIC_CA :="My-Apps\\public-ca" # E.g. TPP-Certificates\\\\Public-CA OR Venafi Cloud App\\issuing-template 
+export CYBR_DOMAIN_FOR_SAMPLE_APP :=example.com
+export CYBR_AWS_ZONE :=foobar
 
-export VEN_CLOUD_BUILTIN_ICA_ROOT_CA_PEM :=./venafi-cloud-built-in-root.pem
-export VEN_CLOUD_ZKPKI_ICA_ROOT_CA_PEM :=./venafi-cloud-zkpki-root.pem
+export CYBR_CLOUD_BUILTIN_ICA_ROOT_CA_PEM :=./venafi-cloud-built-in-root.pem
+export CYBR_CLOUD_ZKPKI_ICA_ROOT_CA_PEM :=./venafi-cloud-zkpki-root.pem
 
-export VEN_TRUST_ANCHOR_ROOT_CA_PEM :=${VEN_CLOUD_BUILTIN_ICA_ROOT_CA_PEM}
-#export VEN_TRUST_ANCHOR_ROOT_CA_PEM :=${VEN_CLOUD_ZKPKI_ICA_ROOT_CA_PEM}
+export CYBR_TRUST_ANCHOR_ROOT_CA_PEM :=${CYBR_CLOUD_BUILTIN_ICA_ROOT_CA_PEM}
+#export CYBR_TRUST_ANCHOR_ROOT_CA_PEM :=${CYBR_CLOUD_ZKPKI_ICA_ROOT_CA_PEM}
 
 ### END - Required only for service mesh usecase #####

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -13,35 +13,35 @@ create-cluster: create-gke-cluster
 
 ## GCP Targets 
 create-gke-cluster:
-	@echo 'Creating GKE Cluster for ${VEN_GCP_PROJECT_ID} in region ${VEN_GCP_REGION}'
-	@./gcp/gke-cluster.sh ${VEN_GCP_PROJECT_ID} ${VEN_GCP_REGION} ${VEN_CLUSTER_NAME}
+	@echo 'Creating GKE Cluster for ${CYBR_GCP_PROJECT_ID} in region ${CYBR_GCP_REGION}'
+	@./gcp/gke-cluster.sh ${CYBR_GCP_PROJECT_ID} ${CYBR_GCP_REGION} ${CYBR_CLUSTER_NAME}
 
 remove-gke-cluster:
-	@gcloud container clusters delete ${VEN_CLUSTER_NAME} --region ${VEN_GCP_REGION}
+	@gcloud container clusters delete ${CYBR_CLUSTER_NAME} --region ${CYBR_GCP_REGION}
 
 create-google-cas:
-	@./gcp/cas.sh ${VEN_GCP_PROJECT_ID} ${VEN_GCP_REGION} ${VEN_DOMAIN_NAME} ${VEN_GCP_CAS_NAME} ${VEN_GCP_CAS_POOL_NAME} ${VEN_GCP_CAS_POOL_TIER}
+	@./gcp/cas.sh ${CYBR_GCP_PROJECT_ID} ${CYBR_GCP_REGION} ${CYBR_DOMAIN_NAME} ${CYBR_GCP_CAS_NAME} ${CYBR_GCP_CAS_POOL_NAME} ${CYBR_GCP_CAS_POOL_TIER}
 
 remove-google-cas:
-	@./gcp/cas-delete.sh ${VEN_GCP_PROJECT_ID} ${VEN_GCP_REGION} ${VEN_DOMAIN_NAME} ${VEN_GCP_CAS_NAME} ${VEN_GCP_CAS_POOL_NAME}
+	@./gcp/cas-delete.sh ${CYBR_GCP_PROJECT_ID} ${CYBR_GCP_REGION} ${CYBR_DOMAIN_NAME} ${CYBR_GCP_CAS_NAME} ${CYBR_GCP_CAS_POOL_NAME}
 
 map-mesh-gateway-ip-to-dns:
 	@rm -f transaction.yaml
-	@./gcp/map-dns-to-gateway.sh ${VEN_GCP_ZONE} ${VEN_DOMAIN_NAME}
+	@./gcp/map-dns-to-gateway.sh ${CYBR_GCP_ZONE} ${CYBR_DOMAIN_NAME}
 
 
 ## AWS Targets
 
 # Create EKS Cluster
 create-eks-cluster:
-	@echo 'Creating EKS Cluster creation with ${VEN_AWS_PROFILE_NAME} in region ${VEN_AWS_REGION}'
-	@./aws/aws-cluster.sh ${VEN_AWS_PROFILE_NAME} ${VEN_AWS_REGION} ${VEN_CLUSTER_NAME}
+	@echo 'Creating EKS Cluster creation with ${CYBR_AWS_PROFILE_NAME} in region ${CYBR_AWS_REGION}'
+	@./aws/aws-cluster.sh ${CYBR_AWS_PROFILE_NAME} ${CYBR_AWS_REGION} ${CYBR_CLUSTER_NAME}
 
 remove-eks-cluster:
-ifeq ($(VEN_AWS_PROFILE_NAME),none)
-	@eksctl delete cluster --region ${VEN_AWS_REGION} --name=${VEN_CLUSTER_NAME}
+ifeq ($(CYBR_AWS_PROFILE_NAME),none)
+	@eksctl delete cluster --region ${CYBR_AWS_REGION} --name=${CYBR_CLUSTER_NAME}
 else
-	@eksctl delete cluster --profile ${VEN_AWS_PROFILE_NAME} --region ${VEN_AWS_REGION} --name=${VEN_CLUSTER_NAME}
+	@eksctl delete cluster --profile ${CYBR_AWS_PROFILE_NAME} --region ${CYBR_AWS_REGION} --name=${CYBR_CLUSTER_NAME}
 endif
 
 create-aws-pca:

--- a/scripts/aws/map-dns-to-gateway.sh
+++ b/scripts/aws/map-dns-to-gateway.sh
@@ -10,4 +10,4 @@ recordvalue="$(kubectl get services --namespace istio-system istio-ingressgatewa
 
 aws --profile basic route53 change-resource-record-sets \
   --hosted-zone-id ${ZONE} \
-  --change-batch '{"Changes":[{"Action":"CREATE","ResourceRecordSet":{"Name":"'${DNS_NAME}.'","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"'${recordvalue}'"}]}}]}'  
+  --change-batch '{"Changes":[{"Action":"CREATE","ResourceRecordSet":{"Name":"'${DNS_NAME}.'","Type":"A","TTL":300,"ResourceRecords":[{"Value":"'${recordvalue}'"}]}}]}'  


### PR DESCRIPTION
All venafi in cluster components now installed in cyberark namespace.  Env variables refer to CYBR.
Please update your local vars.sh and cloud-settings.sh 
If you have a firefly policy restricted to .venafi.svc in the UI , you will need to add or update it to .cyberark.svc