### PR TITLE
Add project to integrate Cyberark Certificate Manager with F5 NGINX Plus with up-to-date README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Each project folder has its own README with setup instructions (or will have one
 | `kong-mesh`      | Kong Mesh integration example | [README](projects/kong-mesh/README.md) |
 | `secrets-manager`      | CyberArk Secrets Manager & Certificate Manager Integration | [README](projects/secrets-manager/README.md) |
 | `ccm-vault`      | Certificate Manager Integration with HashiCorp Vault | [README](projects/ccm-vault/README.md) |
-| `self-hosted`    | Self-hosted Certificate Manager example | [README](projects/self-hosted/README.md) |
-| `spiffe-integration` | SPIFFE/SPIRE workload identity integration | [README](projects/spiffe-integration/README.md) |
+| `nginx-plus`      | Certificate Manager Integration with F5 NGINX Plus | [README](projects/nginx-plus/README.md) |
 
 ---
 

--- a/projects/nginx-plus/01.install-nginx.sh
+++ b/projects/nginx-plus/01.install-nginx.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/env-vars.sh"
+
+# --- Prechecks ---
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+command -v helm >/dev/null 2>&1 || { echo "helm not found"; exit 1; }
+[ -f "$JWT_FILE" ] || { echo "Missing JWT file: $JWT_FILE"; exit 1; }
+
+echo ">> Creating namespace ${NAMESPACE} if it does not exist"
+kubectl get ns "${NAMESPACE}" >/dev/null 2>&1 || kubectl create namespace "${NAMESPACE}"
+
+echo ">> Creating image pull secret (${PULL_SECRET_NAME}) for F5 private registry"
+kubectl -n "${NAMESPACE}" delete secret "${PULL_SECRET_NAME}" --ignore-not-found
+kubectl -n "${NAMESPACE}" create secret docker-registry "${PULL_SECRET_NAME}" \
+  --docker-server=private-registry.nginx.com \
+  --docker-username="$(cat "${JWT_FILE}")" \
+  --docker-password="none"
+
+echo ">> Creating NGINX Plus license secret (${LICENSE_SECRET_NAME})"
+kubectl -n "${NAMESPACE}" delete secret "${LICENSE_SECRET_NAME}" --ignore-not-found
+kubectl -n "${NAMESPACE}" create secret generic "${LICENSE_SECRET_NAME}" \
+  --from-file=license.jwt="${JWT_FILE}" \
+  --type=nginx.com/license
+
+echo ">> Installing NGINX Plus Ingress Controller via Helm (chart ${NGINX_PLUS_VERSION})"
+helm upgrade --install "${RELEASE_NAME}" "${NGINX_PLUS_CHART}" \
+  --version "${NGINX_PLUS_VERSION}" \
+  --namespace "${NAMESPACE}" --create-namespace \
+  --set controller.nginxplus=true \
+  --set controller.image.repository="${IMG_REPO}" \
+  --set controller.serviceAccount.imagePullSecretName="${PULL_SECRET_NAME}" \
+  --set controller.mgmt.licenseTokenSecretName="${LICENSE_SECRET_NAME}" \
+  --set controller.service.type=LoadBalancer \
+  --set controller.enableCertManager=true    # <<< enable cert-manager integration
+
+echo ">> Waiting for controller to be Available..."
+kubectl -n "${NAMESPACE}" wait --for=condition=Available deploy -l app.kubernetes.io/name=nginx-ingress --timeout=180s || true
+
+echo ">> install-nginx.sh complete."

--- a/projects/nginx-plus/02.validate-nginx.sh
+++ b/projects/nginx-plus/02.validate-nginx.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/env-vars.sh"
+
+# --- Prechecks ---
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+# ------------------------------
+# Sample echo app + Service
+# ------------------------------
+echo ">> Ensuring app namespace ${APP_NS}"
+kubectl get ns "${APP_NS}" >/dev/null 2>&1 || kubectl create namespace "${APP_NS}"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP_NAME}
+  namespace: ${APP_NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${APP_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${APP_NAME}
+    spec:
+      containers:
+      - name: ${APP_NAME}
+        image: ${APP_IMAGE}
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${APP_NAME}
+  namespace: ${APP_NS}
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: ${APP_NAME}
+EOF
+
+echo ">> Waiting for echo deployment to be Ready..."
+kubectl -n "${APP_NS}" rollout status deploy/${APP_NAME} --timeout=120s || true
+
+# ------------------------------
+# VirtualServer
+# ------------------------------
+echo ">> Applying VirtualServer ${VS_NAME} (host ${DNS_NAME})"
+cat <<EOF | kubectl apply -f -
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: ${VS_NAME}
+  namespace: ${APP_NS}
+spec:
+  host: ${DNS_NAME}
+  upstreams:
+  - name: ${APP_NAME}-svc
+    service: ${APP_NAME}
+    port: 80
+  routes:
+  - path: /
+    action:
+      pass: ${APP_NAME}-svc
+EOF
+
+echo ">> VirtualServer status:"
+kubectl -n "${APP_NS}" get virtualserver "${VS_NAME}" -o wide || true
+
+# ------------------------------
+# Print LoadBalancer info
+# ------------------------------
+echo ">> Discovering controller LoadBalancer address..."
+LB_IP="$(kubectl -n "${NAMESPACE}" get svc -l app.kubernetes.io/name=nginx-ingress \
+  -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.status.loadBalancer.ingress[0].ip}{end}')"
+LB_HOSTNAME="$(kubectl -n "${NAMESPACE}" get svc -l app.kubernetes.io/name=nginx-ingress \
+  -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.status.loadBalancer.ingress[0].hostname}{end}')"
+
+LB_TARGET="${LB_IP:-$LB_HOSTNAME}"
+
+echo
+if [ -n "${LB_TARGET}" ]; then
+  echo ">> Test HTTP routing with:"
+  echo "curl -i -H \"Host: ${DNS_NAME}\" http://${LB_TARGET}/"
+else
+  echo "!! No LoadBalancer address yet. Check later with:"
+  echo "kubectl get svc -n ${NAMESPACE}"
+  echo "Then test with: curl -i -H \"Host: ${DNS_NAME}\" http://<LB_IP_OR_HOST>/"
+fi
+
+echo ">> Simple NGINX Plus validation complete."

--- a/projects/nginx-plus/03.install-ccm.sh
+++ b/projects/nginx-plus/03.install-ccm.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/env-vars.sh"
+
+# --- Prechecks ---
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+command -v venctl  >/dev/null 2>&1 || { echo "venctl not found (install CyberArk Certificate Manager CLI)"; exit 1; }
+command -v jq      >/dev/null 2>&1 || { echo "jq not found"; exit 1; }
+
+mkdir -p "${TMP_ARTIFACTS_DIR}"
+
+# ------------------------------
+# Create Registry service account in Cyberark Certificate Manager and extract Kubernetes secret
+# ------------------------------
+echo ">> Creating CCM Registry service account: ${CCM_REGISTRY_SVC_ACCT_NAME}"
+venctl iam service-account registry create \
+  --name "${CCM_REGISTRY_SVC_ACCT_NAME}" \
+  --output-file "${TMP_ARTIFACTS_DIR}/${CCM_REGISTRY_SVC_ACCT_NAME}.json" \
+  --output "secret" \
+  --owning-team "${CCM_TEAM_NAME}" \
+  --validity 10 \
+  --scopes cert-manager-components,enterprise-approver-policy,enterprise-venafi-issuer,openshift-routes \
+  --api-key "${CCM_APIKEY}" \
+  --vcp-region "${CCM_CLOUD_REGION}"
+
+jq -r '.image_pull_secret' "${TMP_ARTIFACTS_DIR}/${CCM_REGISTRY_SVC_ACCT_NAME}.json" > "${TMP_ARTIFACTS_DIR}/${CCM_REGISTRY_SVC_ACCT_NAME}.yaml"
+
+echo ">> Ensuring Cyberark Certifcate Manager namespace ${CCM_NAMESPACE}"
+kubectl get ns "${CCM_NAMESPACE}" >/dev/null 2>&1 || kubectl create namespace "${CCM_NAMESPACE}"
+
+echo ">> Creating image pull secret from CCM in cluster"
+kubectl --namespace "${CCM_NAMESPACE}" apply -f "${TMP_ARTIFACTS_DIR}/${CCM_REGISTRY_SVC_ACCT_NAME}.yaml"
+
+# ------------------------------
+# Generate and sync Kubernetes manifests for Cyberark Certificate Manager components
+# ------------------------------
+echo ">> Generating Venafi manifests -> ${CCM_MANIFESTS_FILE}"
+venctl components kubernetes manifest generate \
+  --namespace "${CCM_NAMESPACE}" \
+  --cert-manager \
+  --venafi-connection \
+  --venafi-enhanced-issuer \
+  --default-approver \
+  --image-pull-secret-names venafi-image-pull-secret  > "${CCM_MANIFESTS_FILE}"
+
+echo ">> Applying CyberArk Certificate Manager manifests"
+venctl components kubernetes manifest tool sync --file "${CCM_MANIFESTS_FILE}"
+

--- a/projects/nginx-plus/04.validate-ccm.sh
+++ b/projects/nginx-plus/04.validate-ccm.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/env-vars.sh"
+
+# --- Prechecks ---
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+: "${CCM_NAMESPACE:?CCM_NAMESPACE is required (set in env-vars.sh)}"
+: "${APP_NS:?APP_NS is required (set in env-vars.sh)}"
+: "${CERT_ZONE:?CERT_ZONE is required (set in env-vars.sh)}"
+: "${CCM_APIKEY:?CCM_APIKEY is required (set in env-vars.sh)}"
+: "${DNS_BASE_DOMAIN:?DNS_BASE_DOMAIN is required (set in env-vars.sh, e.g. apps.example.com)}"
+
+# ------------------------------
+# CyberArk API key secret
+# ------------------------------
+echo ">> Creating venafi-cloud-credentials Secret in ${CCM_NAMESPACE}"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: venafi-cloud-credentials
+  namespace: ${CCM_NAMESPACE}
+stringData:
+  venafi-cloud-key: ${CCM_APIKEY}
+EOF
+
+# ------------------------------
+# VenafiConnections: cross-ns and cluster-wide
+# ------------------------------
+echo ">> Creating cross-namespace VenafiConnection in ${CCM_NAMESPACE}"
+kubectl apply -f - <<EOF
+apiVersion: jetstack.io/v1alpha1
+kind: VenafiConnection
+metadata:
+  name: venafi-saas-connection-cross-ns
+  namespace: ${CCM_NAMESPACE}
+spec:
+  allowReferencesFrom:
+    matchLabels:
+      kubernetes.io/metadata.name: ${APP_NS}
+  vaas:
+    url: https://api.venafi.cloud
+    apiKey:
+    - secret:
+        name: venafi-cloud-credentials
+        fields: ["venafi-cloud-key"]
+EOF
+
+echo ">> Creating cluster-wide VenafiConnection in ${CCM_NAMESPACE}"
+kubectl apply -f - <<EOF
+apiVersion: jetstack.io/v1alpha1
+kind: VenafiConnection
+metadata:
+  name: venafi-saas-connection-cluster-wide
+  namespace: ${CCM_NAMESPACE}
+spec:
+  vaas:
+    url: https://api.venafi.cloud
+    apiKey:
+    - secret:
+        name: venafi-cloud-credentials
+        fields: ["venafi-cloud-key"]
+EOF
+
+# ------------------------------
+# RBAC for reading the API key Secret
+# ------------------------------
+echo ">> Applying RBAC so Venafi components can read venafi-cloud-credentials"
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-ccm-credentials
+  namespace: ${CCM_NAMESPACE}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["venafi-cloud-credentials"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-ccm-credentials
+  namespace: ${CCM_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-ccm-credentials
+subjects:
+- kind: ServiceAccount
+  name: venafi-connection
+  namespace: ${CCM_NAMESPACE}
+EOF
+
+# ------------------------------
+# Ensure app namespace and create issuers
+# ------------------------------
+echo ">> Ensuring app namespace ${APP_NS}"
+kubectl get ns "${APP_NS}" >/dev/null 2>&1 || kubectl create namespace "${APP_NS}"
+
+echo ">> Creating VenafiIssuer (namespaced) in ${APP_NS}"
+kubectl apply -f - <<EOF
+apiVersion: jetstack.io/v1alpha1
+kind: VenafiIssuer
+metadata:
+  name: venafi-saas-issuer
+  namespace: ${APP_NS}
+spec:
+  venafiConnectionName: venafi-saas-connection-cross-ns
+  venafiConnectionNamespace: ${CCM_NAMESPACE}
+  zone: ${CERT_ZONE}
+EOF
+
+echo ">> Creating VenafiClusterIssuer (cluster-wide)"
+kubectl apply -f - <<EOF
+apiVersion: jetstack.io/v1alpha1
+kind: VenafiClusterIssuer
+metadata:
+  name: venafi-saas-cluster-issuer
+spec:
+  venafiConnectionName: venafi-saas-connection-cluster-wide
+  zone: ${CERT_ZONE}
+EOF
+
+# ------------------------------
+# Helper: create a Certificate
+# Default CN/SAN = ${DNS_NAME}, or generated from ${DNS_BASE_DOMAIN}
+# ------------------------------
+create_certificate() {
+  local issuer_name="$1"   # e.g., venafi-saas-issuer or venafi-saas-cluster-issuer
+  local issuer_kind="$2"   # VenafiIssuer or VenafiClusterIssuer
+  local issuer_group="$3"  # jetstack.io
+
+  # Compose DNS_NAME if not provided
+  if [[ -z "${DNS_NAME:-}" ]]; then
+    DNS_SUFFIX="$(date +%S%H%M%d%m)"
+    DNS_NAME="nginx-${DNS_SUFFIX}.${DNS_BASE_DOMAIN}"
+  fi
+
+  echo ">> Requesting Certificate ${DNS_NAME} in ${APP_NS} using ${issuer_kind}/${issuer_name} (${issuer_group})"
+  kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${DNS_NAME}
+  namespace: ${APP_NS}
+spec:
+  secretTemplate:
+    labels:
+      app: sample1
+      env: dev
+  secretName: ${DNS_NAME}
+  commonName: ${DNS_NAME}
+  duration: 24h
+  renewBefore: 8h
+  issuerRef:
+    name: ${issuer_name}
+    kind: ${issuer_kind}
+    group: ${issuer_group}
+  privateKey:
+    rotationPolicy: Always
+    size: 2048
+  dnsNames:
+  - ${DNS_NAME}
+EOF
+
+  echo ">> Waiting up to 30s for Certificate ${DNS_NAME} to be Ready..."
+  for i in {1..30}; do
+    READY="$(kubectl -n "${APP_NS}" get certificate "${DNS_NAME}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+    if [[ "${READY}" == "True" ]]; then
+      echo "#################################################"
+      echo "Certificate ${DNS_NAME} is Ready"
+      echo "Secret: ${DNS_NAME} (labels: app=sample1, env=dev)"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "!! Certificate ${DNS_NAME} not Ready after 30s"
+  echo "   Troubleshoot with:"
+  echo "     kubectl -n ${APP_NS} describe certificate ${DNS_NAME}"
+  echo "     kubectl -n ${APP_NS} describe certificaterequest -l cert-manager.io/certificate-name=${DNS_NAME}"
+  return 1
+}
+
+# ------------------------------
+# Behavior:
+#   ./04.validate-ccm.sh                 -> uses namespaced issuer
+#   ./04.validate-ccm.sh use-cluster-issuer -> uses cluster issuer
+# ------------------------------
+if [[ "${1:-}" == "use-cluster-issuer" ]]; then
+  create_certificate "venafi-saas-cluster-issuer" "VenafiClusterIssuer" "jetstack.io"
+else
+  create_certificate "venafi-saas-issuer" "VenafiIssuer" "jetstack.io"
+fi

--- a/projects/nginx-plus/05.create-virtual-server.sh
+++ b/projects/nginx-plus/05.create-virtual-server.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/env-vars.sh"
+
+# --- Prechecks ---
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found"; exit 1; }
+
+APP_NS="${APP_NS:-sandbox}"
+APP_NAME="${APP_NAME:-echo}"
+
+# Optional overrides for hostnames
+: "${VS1_HOST:=${DNS_NAME}}"
+: "${VS2_HOST:=issuer-${DNS_SUFFIX}.${DNS_BASE_DOMAIN}}"
+: "${VS3_HOST:=cluster-${DNS_SUFFIX}.${DNS_BASE_DOMAIN}}"
+
+# Label selector to find the secret created in validate-ccm
+: "${CERT_SECRET_LABEL_SELECTOR:=app=sample1}"
+
+# Issuer names (namespaced and cluster)
+: "${ISSUER_NAME:=venafi-saas-issuer}"
+: "${ISSUER_KIND:=VenafiIssuer}"
+: "${ISSUER_GROUP:=jetstack.io}"
+: "${CLUSTER_ISSUER_NAME:=venafi-saas-cluster-issuer}"
+
+echo ">> Validating service ${APP_NAME} in namespace ${APP_NS}"
+if ! kubectl -n "${APP_NS}" get svc "${APP_NAME}" >/dev/null 2>&1; then
+  echo "ERROR: Service ${APP_NAME} not found in namespace ${APP_NS}. Run 02.validate-nginx.sh first."
+  exit 1
+fi
+
+echo ">> Ensuring namespace ${APP_NS} exists"
+kubectl get ns "${APP_NS}" >/dev/null 2>&1 || kubectl create namespace "${APP_NS}"
+
+# ================================
+# Virtual Server 1 - TLS secret
+# ================================
+echo ">> Looking up TLS secret with label selector '${CERT_SECRET_LABEL_SELECTOR}' in ${APP_NS}"
+VS1_SECRET_NAME="$(kubectl -n "${APP_NS}" get secret -l "${CERT_SECRET_LABEL_SELECTOR}" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | head -n1 || true)"
+
+if [[ -z "${VS1_SECRET_NAME}" ]]; then
+  echo "ERROR: No secret found with label ${CERT_SECRET_LABEL_SELECTOR} in namespace ${APP_NS}."
+  echo "       Make sure 04.validate-ccm.sh created a cert whose secretTemplate includes that label."
+  exit 1
+fi
+
+echo ">> Creating VirtualServer vs1-tlssecret (host: ${VS1_HOST}, secret: ${VS1_SECRET_NAME})"
+cat <<EOF | kubectl apply -f -
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: vs1-tlssecret
+  namespace: ${APP_NS}
+spec:
+  host: ${VS1_HOST}
+  tls:
+    secret: ${VS1_SECRET_NAME}
+  upstreams:
+  - name: ${APP_NAME}-svc
+    service: ${APP_NAME}
+    port: 80
+  routes:
+  - path: /
+    action:
+      pass: ${APP_NAME}-svc
+EOF
+
+# ================================
+# Virtual Server 2 - cert-manager centerprise issuer VenafiIssuer(namespaced)
+# ================================
+echo ">> Creating VirtualServer vs2-issuer (host: ${VS2_HOST}, issuer: ${ISSUER_NAME} kind=${ISSUER_KIND} group=${ISSUER_GROUP})"
+cat <<EOF | kubectl apply -f -
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: vs2-issuer
+  namespace: ${APP_NS}
+spec:
+  host: ${VS2_HOST}
+  tls:
+   secret: ${VS2_HOST}
+   cert-manager:
+     issuer: ${ISSUER_NAME}
+     issuer-kind: ${ISSUER_KIND}
+     issuer-group: ${ISSUER_GROUP}
+     common-name: ${VS2_HOST}
+     duration: 720h
+     renew-before: 480h
+     usages: digital signature,server auth,client auth  
+  upstreams:
+  - name: ${APP_NAME}-svc
+    service: ${APP_NAME}
+    port: 80
+  routes:
+  - path: /
+    action:
+      pass: ${APP_NAME}-svc
+EOF
+
+# ================================
+# Virtual Server 3 - cert-manager enterprise issuer VenafiClusterIssuer 
+# ================================
+echo ">> Creating VirtualServer vs3-clusterissuer (host: ${VS3_HOST}, cluster-issuer: ${CLUSTER_ISSUER_NAME})"
+cat <<EOF | kubectl apply -f -
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: vs3-clusterissuer
+  namespace: ${APP_NS}
+spec:
+  host: ${VS3_HOST}
+  tls:
+    secret: ${VS3_HOST}
+    cert-manager:
+      cluster-issuer: ${CLUSTER_ISSUER_NAME}
+      issuer-kind: VenafiClusterIssuer
+      issuer-group: ${ISSUER_GROUP}
+  upstreams:
+  - name: ${APP_NAME}-svc
+    service: ${APP_NAME}
+    port: 80
+  routes:
+  - path: /
+    action:
+      pass: ${APP_NAME}-svc
+EOF
+
+echo ">> Listing VirtualServers in ${APP_NS}:"
+kubectl -n "${APP_NS}" get virtualserver -o wide || true
+
+LB="$(kubectl -n "${NAMESPACE}" get svc -l app.kubernetes.io/name=nginx-ingress \
+  -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}{"\n"}{.items[0].status.loadBalancer.ingress[0].hostname}{"\n"}' \
+  | head -n1)"
+
+echo ">> Done. Test with (LB=$LB):"
+echo "  VS1_HOST=${VS1_HOST}"
+echo "  VS2_HOST=${VS2_HOST}"
+echo "  VS3_HOST=${VS3_HOST}"
+echo
+echo "  # HTTPS tests"
+echo "  curl -vk --resolve \"${VS1_HOST}:443:${LB}\" https://${VS1_HOST}/"
+echo "  curl -vk --resolve \"${VS2_HOST}:443:${LB}\" https://${VS2_HOST}/"
+echo "  curl -vk --resolve \"${VS3_HOST}:443:${LB}\" https://${VS3_HOST}/"

--- a/projects/nginx-plus/06.cleanup.sh
+++ b/projects/nginx-plus/06.cleanup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/env-vars.sh"
+
+# ------------------------------
+# Delete RBAC
+# ------------------------------
+echo ">> Deleting RBAC for reading CCM credentials"
+kubectl -n "${CCM_NAMESPACE}" delete role read-ccm-credentials --ignore-not-found || true
+kubectl -n "${CCM_NAMESPACE}" delete rolebinding read-ccm-credentials --ignore-not-found || true
+
+# ------------------------------
+# Delete Issuer in app namespace
+# ------------------------------
+echo ">> Deleting VenafiIssuer in ${APP_NS}"
+kubectl -n "${APP_NS}" delete venafiissuer venafi-saas-issuer --ignore-not-found
+echo ">> Deleting VenafiClusterIssuer"
+kubectl delete venaficlusterissuer venafi-saas-cluster-issuer --ignore-not-found
+
+# ------------------------------
+# Delete VenafiConnection and related secrets in CCM namespace
+# ------------------------------
+echo ">> Deleting VenafiConnection and secrets in ${CCM_NAMESPACE}"
+kubectl -n "${CCM_NAMESPACE}" delete venaficonnection venafi-saas-connection-cross-ns --ignore-not-found
+kubectl -n "${CCM_NAMESPACE}" delete venaficonnection venafi-saas-connection-cluster-wide --ignore-not-found
+kubectl -n "${CCM_NAMESPACE}" delete secret venafi-cloud-credentials venafi-image-pull-secret --ignore-not-found
+
+
+# ------------------------------
+# Delete namespaces (optional)
+# ------------------------------
+echo ">> Deleting APP_NS ${APP_NS} (optional)"
+kubectl delete namespace "${APP_NS}" --ignore-not-found || true
+
+# ------------------------------
+# Tear down generated Venafi manifests (if present)
+# ------------------------------
+if [[ -f "${CCM_MANIFESTS_FILE}" ]]; then
+  echo ">> Destroying resources described in ${CCM_MANIFESTS_FILE} via venctl"
+  venctl components kubernetes manifest tool destroy --file "${CCM_MANIFESTS_FILE}" || true
+else
+  echo ">> Skipping venctl destroy: ${CCM_MANIFESTS_FILE} not found"
+fi
+
+helm -n "${NAMESPACE}" uninstall "${RELEASE_NAME}" || true
+
+echo ">> Deleting CCM namespace ${CCM_NAMESPACE}"
+kubectl delete namespace "${CCM_NAMESPACE}" "${NAMESPACE}" --ignore-not-found || true
+
+echo ">> Deleting all leftover CRDS"
+# requires: jq
+delete_crds_by_group() {
+  local group="$1"
+  # Get CRD names for the API group
+  crds="$(kubectl get crds -o json \
+    | jq -r --arg g "$group" '.items[] | select(.spec.group==$g) | .metadata.name')"
+
+  if [ -n "$crds" ]; then
+    echo "$crds" | while IFS= read -r name; do
+      [ -n "$name" ] && kubectl delete crd "$name"
+    done
+  else
+    echo "No CRDs for group: $group"
+  fi
+}
+
+delete_crds_by_group jetstack.io
+delete_crds_by_group cert-manager.io
+delete_crds_by_group acme.cert-manager.io
+delete_crds_by_group k8s.nginx.org
+delete_crds_by_group externaldns.nginx.org
+delete_crds_by_group appprotectdos.f5.com
+delete_crds_by_group appprotect.f5.com
+
+echo ">> cleanup.sh complete."

--- a/projects/nginx-plus/README.md
+++ b/projects/nginx-plus/README.md
@@ -1,0 +1,288 @@
+# NGINX Plus with CyberArk Certificate Manager Demo
+
+This project demonstrates deploying the **NGINX Plus Ingress Controller** and integrating it with **CyberArk Certificate Manager for Kubernetes** .
+
+## Overview
+
+The workflow is organized into step-by-step scripts:
+
+1. **01.install-nginx.sh** – Installs NGINX Plus Ingress Controller in your cluster.
+2. **02.validate-nginx.sh** – Deploys a sample echo service and validates HTTP routing through the ingress.
+3. **03.install-ccm.sh** – Installs CyberArk Certificate Manager components (cert-manager, CCM connection and Enhanced issuer).
+4. **04.validate-ccm.sh** – Validates certificate issuance using a namespaced and/or cluster issuer.
+5. **05.create-virtual-server.sh** – Creates three VirtualServers in the sandbox namespace:
+   - VS1 uses a TLS secret from a pre-created certificate (label `app=sample1`).
+   - VS2 uses inline `tls.cert-manager.issuer` configuration with the namespaced issuer.
+   - VS3 uses `tls.cert-manager.cluster-issuer` configuration with the cluster issuer.
+6. **06.cleanup.sh** – Cleans up all resources, issuers, connections, CRDs, and namespaces.
+
+---
+
+## Getting Started
+
+### Configure Environment Variables
+
+Make a copy of the template and update values:
+
+```bash
+cp env-vars-template.sh env-vars.sh
+```
+
+Edit `env-vars.sh` with your configuration. Everything except those marked as **required** can be left alone.
+
+### Configuration Variables
+
+| Variable Name | Description | Default Value | Required |
+|---------------|-------------|---------------|----------|
+| NAMESPACE | Namespace where NGINX is installed | nginx-ingress | optional |
+| RELEASE_NAME | NGINX Helm chart release name  | nginx-plus | optional |
+| APP_NS | Sample namespace for VirtualServers and Certificates | sandbox | optional |
+| NGINX_PLUS_CHART | OCI Chart location | oci://ghcr.io/nginx/charts/nginx-ingress | optional |
+| NGINX_PLUS_VERSION | Helm Chart version | 2.3.0 | optional |
+| IMG_REPO | NGINX Image Location | private-registry.nginx.com/nginx-ic/nginx-plus-ingress | optional |
+| PULL_SECRET_NAME | Name of the image pull secret for NGINX | regcred | optional |
+| LICENSE_SECRET_NAME | Name of the license secret name | license-token | optional |
+| JWT_FILE | Update to set the path to downloaded JWT file from F5 | <PATH-TO>/nginx-one-eval.jwt | required |
+| CRT_FILE | Update to set the path to downloaded CRT file from F5 | <PATH-TO>/nginx-one-eval.crt | required |
+| KEY_FILE | Update to set the path to downloaded KEY file from F5 | <PATH-TO>/nginx-one-eval.key | required |
+| APP_NAME | Sample deployment name in sandbox namespace | echo | optional |
+| APP_IMAGE | Image for sample deployment | ealen/echo-server:latest | optional |
+| VS_NAME | Virtual Server Name for quick test | demo-vs | optional |
+| DNS_BASE_DOMAIN: | Your domain name | example.com | required |
+| DNS_SUFFIX: | Sample suffix | current datetime | optional |
+| DNS_NAME: |  suffix + DNS_BASE_DOMAIN for certs | nginx-<suffix>.DNS_BASE_DOMAIN | optional |
+| CCM_NAMESPACE | Namespace where Cyberark components are installed | cyberark | optional |
+| CCM_CLOUD_REGION | Cyberark Certificate Manager Region | us | optional |
+| CCM_APIKEY | API Key for your CyberArk Certificate Manager Tenant | REPLACE_WITH_API_KEY | required |
+| CERT_ZONE | Zone from your CyberArk Certificate Manager to issue certs | CloudApps\\Default | required |
+| CCM_REGISTRY_SVC_ACCT_NAME | Name of the OCI registry serivce account in Certificate Manager | cyberark-nic-test-sa | optional |
+| CCM_TEAM_NAME | Name of the Team to associaate with service account (MUST PRE_EXIST) | platform-admin | required |
+| TMP_ARTIFACTS_DIR | Location where temporary files are created | ${HOME}/tmp/nginx-test | optional |
+
+
+---
+
+### Step 1 – Install NGINX Plus
+
+```bash
+./01.install-nginx.sh
+```
+
+This will deploy the NGINX Plus Ingress Controller into the namespace defined in `NAMESPACE` and configure it with your license and registry secrets. cert-manager integration is enabled automatically.
+
+You should see
+```
+.....
+.....
+NAME: nginx-plus
+LAST DEPLOYED: Fri Sep 19 14:46:35 2025
+NAMESPACE: nginx-ingress
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+NGINX Ingress Controller 5.2.0 has been installed.
+
+For release notes for this version please see: https://docs.nginx.com/nginx-ingress-controller/releases/
+
+Installation and upgrade instructions: https://docs.nginx.com/nginx-ingress-controller/installation/installing-nic/installation-with-helm/
+>> Waiting for controller to be Available...
+deployment.apps/nginx-plus-nginx-ingress-controller condition met
+>> install-nginx.sh complete.
+```
+
+Confirm that you have a valid IP by running
+```
+kubectl get svc -n nginx-ingress
+```
+and you should see
+
+```
+❯ k get svc -n nginx-ingress
+NAME                                  TYPE           CLUSTER-IP    EXTERNAL-IP      PORT(S)                      AGE
+nginx-plus-nginx-ingress-controller   LoadBalancer   10.0.120.21   xxx.xxx.xxx.xxx   80:32370/TCP,443:31712/TCP   42s
+
+```
+
+### Step 2 – Validate HTTP Routing
+
+```bash
+./02.validate-nginx.sh
+```
+
+Deploys a sample `echo` service and exposes it through a VirtualServer. Use the printed curl command to test.
+You should see 
+```
+❯ ./02.validate-nginx.sh
+>> Ensuring app namespace sandbox
+namespace/sandbox created
+deployment.apps/echo created
+service/echo created
+>> Waiting for echo deployment to be Ready...
+Waiting for deployment "echo" rollout to finish: 0 of 1 updated replicas are available...
+deployment "echo" successfully rolled out
+>> Applying VirtualServer demo-vs (host nginx-1714501909.svc.cluster.local)
+virtualserver.k8s.nginx.org/demo-vs created
+>> VirtualServer status:
+NAME      STATE   HOST                                 IP               EXTERNALHOSTNAME   PORTS      AGE
+demo-vs   Valid   nginx-1714501909.svc.cluster.local   xxx.xxx.xxx.xxx                     [80,443]   0s
+>> Discovering controller LoadBalancer address...
+
+>> Test HTTP routing with:
+curl -i -H "Host: nginx-1714501909.svc.cluster.local" http://xxx.xxx.xxx.xxx/
+>> Simple NGINX Plus validation complete.
+
+```
+**Run the test command** to see
+
+```
+❯ curl -i -H "Host: nginx-1714501909.svc.cluster.local" http://xxx.xxx.xxx.xxx/
+HTTP/1.1 200 OK
+Server: nginx/1.29.0
+Date: Fri, 19 Sep 2025 19:51:24 GMT
+Content-Type: application/json; charset=utf-8
+Content-Length: 1254
+Connection: keep-alive
+ETag: W/"4e6-I/ykx6TJhH1V08kQWOQNoFJSkIc"
+
+{"host":{"hostname":"nginx-1714501909.svc.cluster.local","ip
+.....
+.....
+```
+
+This confirms your NGINX Plus install is working as expected. 
+
+### Step 3 – Install CyberArk Certificate Manager
+
+```bash
+./03.install-ccm.sh
+```
+
+Installs the necessary CyberArk Certificate Manager and Venafi components into the `CCM_NAMESPACE`.
+
+Once the installation is complete you should see the following on the screen. 
+
+```
+❯ ./03.install-ccm.sh
+>> Creating CCM Registry service account: cyberark-nic-test-sa
+....
+....
+....
+UPDATED RELEASES:
+NAME                     NAMESPACE   CHART                                  VERSION   DURATION
+venafi-connection        cyberark    venafi-charts/venafi-connection        v0.4.0          3s
+cert-manager             cyberark    venafi-charts/cert-manager             v1.18.2        36s
+venafi-enhanced-issuer   cyberark    venafi-charts/venafi-enhanced-issuer   v0.16.0        21s
+```
+
+### Step 4 – Validate Certificate Issuance
+
+```bash
+./04.validate-ccm.sh               # Namespaced issuer (default)
+./04.validate-ccm.sh use-cluster-issuer   # Cluster issuer
+```
+
+Requests a TLS certificate. The secret is labeled `app=sample1` for use by VirtualServer VS1.
+You should see the following output when you validate certificate issuance
+
+```
+❯ ./04.validate-ccm.sh
+>> Creating venafi-cloud-credentials Secret in cyberark
+secret/venafi-cloud-credentials created
+>> Creating cross-namespace VenafiConnection in cyberark
+venaficonnection.jetstack.io/venafi-saas-connection-cross-ns created
+>> Creating cluster-wide VenafiConnection in cyberark
+venaficonnection.jetstack.io/venafi-saas-connection-cluster-wide created
+>> Applying RBAC so Venafi components can read venafi-cloud-credentials
+role.rbac.authorization.k8s.io/read-ccm-credentials created
+rolebinding.rbac.authorization.k8s.io/read-ccm-credentials created
+>> Ensuring app namespace sandbox
+>> Creating VenafiIssuer (namespaced) in sandbox
+venafiissuer.jetstack.io/venafi-saas-issuer created
+>> Creating VenafiClusterIssuer (cluster-wide)
+venaficlusterissuer.jetstack.io/venafi-saas-cluster-issuer created
+>> Requesting Certificate nginx-1014571909.svc.cluster.local in sandbox using VenafiIssuer/venafi-saas-issuer (jetstack.io)
+certificate.cert-manager.io/nginx-1014571909.svc.cluster.local created
+>> Waiting up to 30s for Certificate nginx-1014571909.svc.cluster.local to be Ready...
+#################################################
+Certificate nginx-1014571909.svc.cluster.local is Ready
+Secret: nginx-1014571909.svc.cluster.local (labels: app=sample1, env=dev)
+```
+
+Optionally run it again with `./04.validate-ccm.sh use-cluster-issuer` to request another certificate with `VenafiClusterIssuer`
+
+### Step 5 – Create VirtualServers
+
+```bash
+./05.create-virtual-server.sh
+```
+
+Creates three VirtualServers:
+- **vs1-tlssecret** → uses the labeled TLS secret.
+- **vs2-issuer** → uses the namespaced issuer inline in the spec.
+- **vs3-clusterissuer** → uses the cluster issuer inline in the spec.
+
+Running this should show 
+
+```
+❯ ./05.create-virtual-server.sh
+>> Validating service echo in namespace sandbox
+>> Ensuring namespace sandbox exists
+>> Looking up TLS secret with label selector 'app=sample1' in sandbox
+>> Creating VirtualServer vs1-tlssecret (host: nginx-3514591909.svc.cluster.local, secret: nginx-1014571909.svc.cluster.local)
+virtualserver.k8s.nginx.org/vs1-tlssecret created
+>> Creating VirtualServer vs2-issuer (host: issuer-3514591909.svc.cluster.local, issuer: venafi-saas-issuer kind=VenafiIssuer group=jetstack.io)
+virtualserver.k8s.nginx.org/vs2-issuer created
+>> Creating VirtualServer vs3-clusterissuer (host: cluster-3514591909.svc.cluster.local, cluster-issuer: venafi-saas-cluster-issuer)
+virtualserver.k8s.nginx.org/vs3-clusterissuer created
+>> Listing VirtualServers in sandbox:
+NAME                STATE     HOST                                   IP               EXTERNALHOSTNAME   PORTS      AGE
+demo-vs             Valid     nginx-1714501909.svc.cluster.local     xxx.xxx.xxx.xxx                     [80,443]   9m12s
+vs1-tlssecret       Valid     nginx-3514591909.svc.cluster.local     xxx.xxx.xxx.xxx                     [80,443]   20s
+vs2-issuer          Valid     issuer-3514591909.svc.cluster.local    xxx.xxx.xxx.xxx                     [80,443]   20s
+vs3-clusterissuer   Warning   cluster-3514591909.svc.cluster.local   xxx.xxx.xxx.xxx                     [80,443]    0s
+
+>> Done. Test with (LB=xxx.xxx.xxx.xxx):
+  VS1_HOST=nginx-3514591909.svc.cluster.local
+  VS2_HOST=issuer-3514591909.svc.cluster.local
+  VS3_HOST=cluster-3514591909.svc.cluster.local
+
+  # HTTPS tests
+  curl -vk --resolve "nginx-3514591909.svc.cluster.local:443:xxx.xxx.xxx.xxx" https://nginx-3514591909.svc.cluster.local/
+  curl -vk --resolve "issuer-3514591909.svc.cluster.local:443:xxx.xxx.xxx.xxx" https://issuer-3514591909.svc.cluster.local/
+  curl -vk --resolve "cluster-3514591909.svc.cluster.local:443:xxx.xxx.xxx.xxx" https://cluster-3514591909.svc.cluster.local/
+```
+Wait for a few seconds and run `kubectl get VirtualServer -n sandbox` to see
+
+```
+❯ kubectl get VirtualServer -n sandbox
+NAME                STATE     HOST                                   IP               PORTS      AGE
+demo-vs             Valid     nginx-1714501909.svc.cluster.local     xxx.xxx.xxx.xxx  [80,443]   11m
+vs1-tlssecret       Valid     nginx-3514591909.svc.cluster.local     xxx.xxx.xxx.xxx  [80,443]   119s
+vs2-issuer          Valid     issuer-3514591909.svc.cluster.local    xxx.xxx.xxx.xxx  [80,443]   119s
+vs3-clusterissuer   Warning   cluster-3514591909.svc.cluster.local   xxx.xxx.xxx.xxx  [80,443]   118s
+```
+
+Use the commands from HTTPS tests to validate that VirtualServer works as expected with TLS. The `vs3-clusterissuer` will not work as it has issues that needs to be addressed in NGINX Plus.
+
+### Step 6 – Cleanup
+
+```bash
+./06.cleanup.sh
+```
+
+Deletes all namespaces, issuers, secrets, CRDs, and local artifacts created during the demo.
+
+---
+
+## Notes
+
+- Cert-manager integration is enabled via `controller.enableCertManager=true` in the NGINX Plus Helm chart.
+- All scripts source variables from `env-vars.sh` to avoid hardcoding values.
+- Certificate issuance requires a valid `CERT_ZONE` and `CCM_APIKEY` associated with your CyberArk environment.
+
+---
+
+## License
+
+This demo requires a valid **NGINX Plus license** and a valid **CyberArk Certificate Manager API key**.

--- a/projects/nginx-plus/env-vars-template.sh
+++ b/projects/nginx-plus/env-vars-template.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# =====================================================================
+# env-vars.sh
+# Centralized configuration for the scripts,
+# Source this file from the scripts:
+#   source "$(dirname "$0")/env-vars.sh"
+# You can override any value by exporting it before sourcing this file.
+# =====================================================================
+
+# Export all variables defined below
+set -a
+
+# ------------------------------
+# General
+# ------------------------------
+# Namespace that hosts NGINX Ingress Controller (Plus)
+NAMESPACE="${NAMESPACE:-nginx-ingress}" #optional
+# Helm release name for NGINX Plus IC
+RELEASE_NAME="${RELEASE_NAME:-nginx-plus}" #optional
+
+# Namespace for sample app / certificates
+APP_NS="${APP_NS:-sandbox}" #optional
+
+# ------------------------------
+# NGINX Plus Ingress Controller (F5)
+# ------------------------------
+NGINX_PLUS_CHART="${NGINX_PLUS_CHART:-oci://ghcr.io/nginx/charts/nginx-ingress}" #optional
+# Helm chart version for NIC (this is the CHART version, not your helm client)
+NGINX_PLUS_VERSION="${NGINX_PLUS_VERSION:-2.3.0}" #optional
+
+# NGINX Plus controller image repo (private F5 registry)
+IMG_REPO="${IMG_REPO:-private-registry.nginx.com/nginx-ic/nginx-plus-ingress}" #optional
+# Image pull secret name used by the controller SA
+PULL_SECRET_NAME="${PULL_SECRET_NAME:-regcred}" #optional
+# License token secret name for runtime (type=nginx.com/license)
+LICENSE_SECRET_NAME="${LICENSE_SECRET_NAME:-license-token}" #optional
+
+# Paths to F5 license artifacts (JWT required; CRT/KEY optional here)
+# TIP: you can set these to relative paths (e.g., ./creds/nginx-one-eval.jwt)
+JWT_FILE="${JWT_FILE:-<PATH-TO>/nginx-one-eval.jwt}" #required
+CRT_FILE="${CRT_FILE:-<PATH-TO>/nginx-one-eval.crt}" #required
+KEY_FILE="${KEY_FILE:-<PATH-TO>/nginx-one-eval.key}" #required
+
+# ---------------------------------------
+# Sample Application (echo) + VirtualServer
+# ---------------------------------------
+APP_NAME="${APP_NAME:-echo}" #optional
+APP_IMAGE="${APP_IMAGE:-ealen/echo-server:latest}" #optional
+VS_NAME="${VS_NAME:-demo-vs}" #optional
+
+: "${DNS_BASE_DOMAIN:=svc.cluster.local}" # or your real domain, e.g. example.com #required
+
+# One-time suffix;
+: "${DNS_SUFFIX:=$(date +%S%H%M%d%m)}" #optional
+
+# Compose a default FQDN if none provided
+# If you want predictable cert names, set DNS_NAME explicitly; otherwise
+# the installer will generate one using the format -> suffix + DNS_BASE_DOMAIN .
+
+: "${DNS_NAME:=nginx-${DNS_SUFFIX}.${DNS_BASE_DOMAIN}}" #optional
+
+# ------------------------------
+# CyberArk Certificate Manager variables
+# ------------------------------
+# Namespace for CyberArk Certificate Manager components
+CCM_NAMESPACE="${CCM_NAMESPACE:-cyberark}" #optional
+# CCM Cloud region: us | eu | apj
+CCM_CLOUD_REGION="${CCM_CLOUD_REGION:-us}" #optional
+# CyberArk Certificate Manager API Key
+CCM_APIKEY="${CCM_APIKEY:-REPLACE_WITH_API_KEY}" #required
+# Certificate Manager zone to issue certs from, e.g., "Application\\ZoneName"
+CERT_ZONE="${CERT_ZONE:-CloudApps\\Default}" #required
+
+# Service Account created in CCM Registry for pulling images
+CCM_REGISTRY_SVC_ACCT_NAME="${CCM_REGISTRY_SVC_ACCT_NAME:-cyberark-nic-test-sa}" #optional
+# Team that owns the service account (must exist)
+CCM_TEAM_NAME="${CCM_TEAM_NAME:-platform-admin}" #required
+# Where to place generated artifacts locally
+TMP_ARTIFACTS_DIR="${TMP_ARTIFACTS_DIR:-${HOME}/tmp/nginx-test}" #optional
+# Where to persist the generated Kubernetes manifests
+CCM_MANIFESTS_FILE="${CCM_MANIFESTS_FILE:-${TMP_ARTIFACTS_DIR}/venafi-manifests.yaml}" #optional
+
+# Stop exporting new variables
+set +a


### PR DESCRIPTION
Support for NGINX Plus with VirtualServer that are TLS enabled. 
After the validation there should be 4 VirtualServers in the sandbox namespace. 
demo-vs - HTTP Only
vs1-tlssecret - VirtualServer configured with secret from precreated Certificate
vs1-issuer - Uses VirtualServer's inline support for namespaced issuers 
vs1-clusterissuer - Uses VirtualServer's inline support for cluster issuers [This does not work - NGINX Plus needs to fix]